### PR TITLE
[TAO-1796][Feature] [AIRE] fix(ci): resolve 1 bug(s) from PR #36 (run 31448189096)

### DIFF
--- a/tests/clip/__init__.py
+++ b/tests/clip/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLIP Unit Tests."""

--- a/tests/video_clip/__init__.py
+++ b/tests/video_clip/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Video CLIP Unit Tests."""


### PR DESCRIPTION
## What this PR fixes

Blossom-CI run [`31448189096`](https://github.com/NVIDIA-TAO/tao-deploy/actions/runs/31448189096) on PR #36 aborted during pytest collection:

```
!!!!!!!!!!!!!!!!!!! Interrupted: 6 errors during collection !!!!!!!!!!!!!!!!!!!!
======================= 60 warnings, 6 errors in 13.03s ========================
hudson.AbortException: script returned exit code 2
```

This PR targets `dev/video-clip-trt-deploy` (the branch of PR #36) so the fix lands together with the work under test.

Fixes NVIDIA-TAO/tao-deploy#37

---

### Bug `g1` — pytest "import file mismatch" between `tests/clip` and `tests/video_clip`

**Failure class:** `test_failure` (collection error) · **Confidence:** high

**Root cause.** PR #36 adds `tests/video_clip/` whose six test modules share **exact basenames** with the pre-existing `tests/clip/` directory (`test_config.py`, `test_dataloader.py`, `test_engine_builder.py`, `test_entrypoint.py`, `test_evaluation.py`, `test_inferencer.py`).

Neither directory had an `__init__.py` — they were the **only two** of the 26 directories under `tests/` that are not Python packages. Under pytest's default `prepend` import mode, test files in a non-package directory are imported under their **bare basename**, so both `tests/clip/test_config.py` and `tests/video_clip/test_config.py` claimed the module name `test_config`:

```
ERROR collecting tests/video_clip/test_config.py
import file mismatch:
imported module 'test_config' has this __file__ attribute:
  .../tests/clip/test_config.py
which is not the same as the test file we want to collect:
  .../tests/video_clip/test_config.py
HINT: remove __pycache__ / .pyc files and/or use a unique basename for your test file modules
```

Six collisions → `6 errors during collection` → pytest exit `2` → Jenkins `AbortException`. Because collection is *interrupted*, none of the 275 collected tests ran.

**What this PR changes.**

| File | Change |
|---|---|
| `tests/video_clip/__init__.py` | **added** — makes the new directory a package |
| `tests/clip/__init__.py` | **added** — makes its counterpart a package too |

Both follow the convention already used by all 24 other `tests/` subpackages (SPDX header + one-line docstring).

With both directories as packages (and no `tests/__init__.py`), pytest walks up to `tests/` as the base directory and derives **unique** module names — `clip.test_config` vs `video_clip.test_config` — so the collision disappears. Adding it to both directories (rather than only the new one) keeps the suite internally consistent instead of special-casing `video_clip`.

No test logic, source code, or CI configuration is modified — this is purely test-package plumbing.

### Known issues without a fix

None — all detected failures in this run are addressed above.

---

🤖 Generated automatically by **AIRE** (NVIDIA automated CI agent) from run `31448189096`.

Signed-off-by: svc-bcs-agent <svc-bcs-agent@nvidia.com>

<!-- AIRE-META
source_pr: 36
source_head_sha: 55dda1c0d34983830d3b8af930499c0452ebb2c1
source_repo: NVIDIA-TAO/tao-deploy
dest_repo: NVIDIA-TAO/tao-deploy
fix_branch: fix/tao-deploy-55dda1c
run_id: 31448189096
issue: 37
-->
