### PR TITLE
[TLT-5923][Bugfix] Align Visual ChangeNet FPR and FNR

### DIFF
--- a/nvidia_tao_deploy/cv/visual_changenet/classification/utils.py
+++ b/nvidia_tao_deploy/cv/visual_changenet/classification/utils.py
@@ -55,11 +55,25 @@ class AOIMetrics:
         Returns:
             dict: Dictionary containing the computed metrics.
         """
+        total = self.tot_pass + self.tot_fail
+        zero = np.zeros_like(total, dtype=float)
         metric_collect = {}
-        metric_collect['total_accuracy'] = ((self.match_pass + self.match_fail) / (self.tot_pass + self.tot_fail)) * 100
-        metric_collect['defect_accuracy'] = 0 if self.tot_fail == 0 else (self.match_fail / self.tot_fail) * 100
-        metric_collect['false_alarm'] = (self.mismatch_pass / (self.tot_pass + self.tot_fail)) * 100
-        metric_collect['false_negative'] = (self.mismatch_fail / (self.tot_pass + self.tot_fail)) * 100
+        metric_collect['total_accuracy'] = (
+            zero if total == 0 else
+            ((self.match_pass + self.match_fail) / total) * 100
+        )
+        metric_collect['defect_accuracy'] = (
+            zero if self.tot_fail == 0 else
+            (self.match_fail / self.tot_fail) * 100
+        )
+        metric_collect['false_alarm'] = (
+            zero if self.tot_pass == 0 else
+            (self.mismatch_pass / self.tot_pass) * 100
+        )
+        metric_collect['false_negative'] = (
+            zero if self.tot_fail == 0 else
+            (self.mismatch_fail / self.tot_fail) * 100
+        )
 
         return metric_collect
 

--- a/tests/visual_changenet/test_metrics.py
+++ b/tests/visual_changenet/test_metrics.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Visual ChangeNet classification metric regression tests."""
+
+import numpy as np
+import pytest
+
+from nvidia_tao_deploy.cv.visual_changenet.classification.utils import AOIMetrics
+
+
+@pytest.mark.visual_changenet
+def test_false_rates_use_their_class_denominators():
+    """FPR is over pass samples and FNR is over defect samples."""
+    metrics = AOIMetrics(margin=2.0)
+    predictions = np.array([0, 0, 0, 0, 0, 0, 3, 3, 3, 0])
+    targets = np.array([0, 0, 0, 0, 0, 0, 0, 0, 1, 1])
+
+    metrics.update(predictions, targets)
+    result = metrics.compute()
+
+    assert result["total_accuracy"].item() == pytest.approx(70.0)
+    assert result["defect_accuracy"].item() == pytest.approx(50.0)
+    assert result["false_alarm"].item() == pytest.approx(25.0)
+    assert result["false_negative"].item() == pytest.approx(50.0)
+
+
+@pytest.mark.visual_changenet
+@pytest.mark.parametrize(
+    ("predictions", "targets", "expected_false_alarm", "expected_false_negative"),
+    (
+        (np.array([0, 3]), np.array([1, 1]), 0.0, 50.0),
+        (np.array([3, 0]), np.array([0, 0]), 50.0, 0.0),
+    ),
+)
+def test_false_rates_handle_single_class_inputs(
+    predictions, targets, expected_false_alarm, expected_false_negative
+):
+    """An absent class gets zero while the present class keeps its error rate."""
+    metrics = AOIMetrics(margin=2.0)
+    metrics.update(predictions, targets)
+
+    result = metrics.compute()
+
+    assert np.isfinite(result["total_accuracy"])
+    assert result["false_alarm"].item() == expected_false_alarm
+    assert result["false_negative"].item() == expected_false_negative
+
+
+@pytest.mark.visual_changenet
+def test_metrics_handle_empty_state():
+    """Computing before an update returns finite zero metrics."""
+    result = AOIMetrics().compute()
+
+    assert all(metric.item() == 0.0 for metric in result.values())


### PR DESCRIPTION
### What changes are proposed in this pull request?

- Compute Visual ChangeNet deployment false-positive rate over actual PASS samples.
- Compute false-negative rate over actual defect samples.
- Return finite zero values for empty or absent-class inputs.
- Add CPU regression coverage for mixed, all-PASS, all-defect, and empty inputs.

### Why are the changes needed?

The shared TAO Deploy `AOIMetrics` utility normalized both false-positive and
false-negative counts by the total dataset size. NVIDIA-TAO/tao-pytorch#107
corrected the PyTorch evaluator to use conventional class-conditional
denominators, leaving TensorRT/deployment evaluation with different KPI values
for the same checkpoint and dataset.

### Related issues

- [TLT-5923](https://jirasw.nvidia.com/browse/TLT-5923)
- [NVBug 6603000](https://nvbugs.nvidia.com/bug/6603000)
- Companion runtime fix: NVIDIA-TAO/tao-pytorch#107
- Fixes #41

### Does this PR introduce _any_ user-facing change?

Yes. Deployment evaluation now reports conventional class-conditional FPR and
FNR percentages. Existing KPI baselines may shift upward because the denominator
changes from all samples to the relevant ground-truth class; values remain
percentages.

### How was this patch tested?

Using the exact ARM64 image pinned in `docker/manifest.json`:

```text
python3 -m pytest -q tests/visual_changenet/test_metrics.py

4 passed
```

The following changed-file checks also passed in the pinned image:

```text
license header: Passed
pylint: 10.00/10
pydocstyle: Passed
flake8: Passed
Python compilation: Passed
git diff --check: Passed
DCO sign-off: Passed
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)

### Release note

```release-note
Aligned Visual ChangeNet deployment FPR and FNR with conventional class-conditional percentages and added absent-class guards.
```

### Checklist

- [x] My commit is signed off per the DCO (`git commit -s`).
- [x] I have read the contributing guidelines.
- [x] The code follows the repository style, and applicable static checks pass.
- [x] I added regression tests covering the change.
- [x] All applicable focused tests pass in the pinned repository image.
- [ ] I updated documentation (not required; metric names and percentage units are unchanged).
- [ ] I updated the version or changelog (handled by the release backport workflow).
- [x] No secrets, credentials, proprietary data, or customer data are included.
- [x] I understand the contribution and sign-off become part of the public history.

### Notes for reviewers

- The formulas now match NVIDIA-TAO/tao-pytorch#107 exactly.
- `false_alarm = mismatch_pass / tot_pass * 100`.
- `false_negative = mismatch_fail / tot_fail * 100`.
- Empty and missing-class denominators return a shape-compatible NumPy zero.
- Model execution, checkpoint contents, and raw predictions are unchanged.
