### PR TITLE
[TAOVN-1258][Feature] Add NVPanoptix3Dv2 TensorRT deployment support

### DIFF
--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/__init__.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 configuration package."""

--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/dataset.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/dataset.py
@@ -1,0 +1,253 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the dataset."""
+
+from typing import List, Optional
+from dataclasses import dataclass
+
+from nvidia_tao_deploy.config.utils.types import (
+    BOOL_FIELD,
+    DATACLASS_FIELD,
+    FLOAT_FIELD,
+    INT_FIELD,
+    LIST_FIELD,
+    STR_FIELD
+)
+
+
+@dataclass
+class PhotometricAugmentationConfig:
+    """Geometry-safe photometric augmentation config.
+
+    One recipe is sampled per multi-view sample and applied identically to
+    every view, so no spatial operation or geometric target is modified.
+    Training only.
+    """
+
+    enabled: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="enable photometric augmentation",
+        description="Flag to enable RGB-only training augmentation.",
+    )
+    color_jitter_prob: float = FLOAT_FIELD(
+        value=0.8,
+        default_value=0.8,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="color jitter probability",
+        description="Probability of applying brightness/contrast/saturation jitter.",
+    )
+    brightness: float = FLOAT_FIELD(
+        value=0.10,
+        default_value=0.10,
+        valid_min=0.0,
+        display_name="brightness",
+        description="Maximum relative brightness jitter.",
+    )
+    contrast: float = FLOAT_FIELD(
+        value=0.10,
+        default_value=0.10,
+        valid_min=0.0,
+        display_name="contrast",
+        description="Maximum relative contrast jitter.",
+    )
+    saturation: float = FLOAT_FIELD(
+        value=0.15,
+        default_value=0.15,
+        valid_min=0.0,
+        display_name="saturation",
+        description="Maximum relative saturation jitter.",
+    )
+    gamma_exposure_prob: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="gamma/exposure probability",
+        description="Probability of applying the gamma and exposure jitter.",
+    )
+    gamma: float = FLOAT_FIELD(
+        value=0.10,
+        default_value=0.10,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="gamma",
+        description="Maximum gamma jitter. Must be in [0, 1).",
+    )
+    exposure_ev: float = FLOAT_FIELD(
+        value=0.15,
+        default_value=0.15,
+        valid_min=0.0,
+        display_name="exposure EV",
+        description="Maximum exposure jitter in EV stops.",
+    )
+    grayscale_prob: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="grayscale probability",
+        description="Probability of converting a sample to grayscale.",
+    )
+
+
+@dataclass
+class PanopticDatasetConfig:
+    """Dataset config for the panoptic variant (preprocessed ScanNet++ trees)."""
+
+    train_preprocessed_root: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="training preprocessed root",
+        description="""
+        Preprocessed ScanNet++ training root containing
+        :code:`all_metadata.npz`, :code:`categories.json`, and the scene
+        directories. The metadata file includes the training pair table.""",
+    )
+    val_preprocessed_root: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="validation preprocessed root",
+        description="""
+        Preprocessed ScanNet++ validation root containing
+        :code:`all_metadata.npz`, :code:`categories.json`, and the scene
+        directories. The metadata file includes the validation pair table.""",
+    )
+    photometric_augmentation: PhotometricAugmentationConfig = DATACLASS_FIELD(
+        PhotometricAugmentationConfig(),
+        display_name="photometric augmentation",
+        description="Configuration parameters for the training-only RGB augmentation.",
+    )
+    num_views: int = INT_FIELD(
+        value=5,
+        default_value=5,
+        valid_min=2,
+        display_name="number of views",
+        description="Number of views per multi-view sample.",
+        popular="yes",
+    )
+    randomize_view_order: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="randomize view order",
+        description="""
+        Training only. Select either central anchor as VGGT reference view 0,
+        then shuffle the remaining views. Validation and test ignore this flag
+        and use stable index-seeded sampling.""",
+    )
+    num_workers: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=0,
+        display_name="num workers",
+        description="Number of dataloader workers for every split.",
+    )
+    pairs_per_scene: int = INT_FIELD(
+        value=50,
+        default_value=50,
+        valid_min=1,
+        display_name="pairs per scene",
+        description="Samples drawn per scene from the primary root.",
+    )
+    batch_size: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        display_name="batch size",
+        description="Number of multi-view samples per GPU.",
+        popular="yes",
+    )
+    resolution: List[List[int]] = LIST_FIELD(
+        arrList=[[518, 518], [518, 378], [518, 322]],
+        default_value=[[518, 518], [518, 378], [518, 322]],
+        display_name="resolution buckets",
+        description="""
+        Aspect-ratio buckets as [H, W] pairs. One bucket is selected per sample
+        from the anchor view's aspect ratio; a single entry reproduces
+        fixed-resolution behaviour.""",
+    )
+
+
+@dataclass
+class ReasoningDatasetConfig:
+    """Dataset config for the reasoning variant (JSONL reasoning manifests)."""
+
+    train_manifest: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="train manifest",
+        description="""
+        Path to the training JSONL manifest. Each line holds the view image
+        paths, the RGB-encoded panoptic PNGs, the instruction/answer pair, and
+        the target instance id.""",
+    )
+    val_manifest: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="val manifest",
+        description="Path to the validation JSONL manifest. Null disables validation.",
+    )
+    require_seg_token: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="require SEG token",
+        description="""
+        Drop training records whose answer has a target instance but no
+        :code:`[SEG]` token, which would otherwise yield no mask supervision.""",
+    )
+    resolution: List[int] = LIST_FIELD(
+        arrList=[518, 518],
+        default_value=[518, 518],
+        display_name="resolution",
+        description="Square letterbox size [H, W] every view is resized to, matching VGGT.",
+    )
+    num_views: int = INT_FIELD(
+        value=5,
+        default_value=5,
+        valid_min=1,
+        display_name="number of views",
+        description="Number of views per sample. 1 reproduces the single-view setting.",
+        popular="yes",
+    )
+    batch_size: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        display_name="batch size",
+        description="Number of multi-view samples per GPU.",
+        popular="yes",
+    )
+    num_workers: int = INT_FIELD(
+        value=4,
+        default_value=4,
+        valid_min=0,
+        display_name="num workers",
+        description="Number of dataloader workers for every split.",
+    )
+    depth_scale: float = FLOAT_FIELD(
+        value=1000.0,
+        default_value=1000.0,
+        math_cond="> 0.0",
+        display_name="depth scale",
+        description="""
+        Stored depth units per metre (ScanNet++: 1000). Per-record values in
+        the manifest override this fallback.""",
+    )
+
+
+@dataclass
+class NVPanoptix3Dv2DatasetConfig:
+    """Data config.
+
+    Each variant owns a self-contained sub-block; :code:`model.model_type`
+    selects which one the data module reads.
+    """
+
+    panoptic: PanopticDatasetConfig = DATACLASS_FIELD(
+        PanopticDatasetConfig(),
+        display_name="panoptic dataset",
+        description="Dataset for the panoptic variant. Read when model_type is panoptic.",
+    )
+    reasoning: ReasoningDatasetConfig = DATACLASS_FIELD(
+        ReasoningDatasetConfig(),
+        display_name="reasoning dataset",
+        description="Dataset for the reasoning variant. Read when model_type is reasoning.",
+    )

--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/default_config.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/default_config.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Default config file."""
+
+from dataclasses import dataclass
+
+from nvidia_tao_deploy.config.utils.types import (
+    DATACLASS_FIELD,
+)
+from nvidia_tao_deploy.config.common.common_config import (
+    CommonExperimentConfig
+)
+
+from nvidia_tao_deploy.config.nvpanoptix3d_v2.dataset import NVPanoptix3Dv2DatasetConfig
+from nvidia_tao_deploy.config.nvpanoptix3d_v2.deploy import NVPanoptix3Dv2GenTRTEngineExpConfig
+from nvidia_tao_deploy.config.nvpanoptix3d_v2.evaluate import NVPanoptix3Dv2EvaluateExpConfig
+from nvidia_tao_deploy.config.nvpanoptix3d_v2.export import NVPanoptix3Dv2ExportExpConfig
+from nvidia_tao_deploy.config.nvpanoptix3d_v2.inference import NVPanoptix3Dv2InferenceExpConfig
+from nvidia_tao_deploy.config.nvpanoptix3d_v2.model import NVPanoptix3Dv2ModelConfig
+from nvidia_tao_deploy.config.nvpanoptix3d_v2.train import NVPanoptix3Dv2TrainExpConfig
+
+
+@dataclass
+class ExperimentConfig(CommonExperimentConfig):
+    """Experiment config."""
+
+    model: NVPanoptix3Dv2ModelConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2ModelConfig(),
+        description="Configurable parameters to construct the model for the NVPanoptix3Dv2 experiment.",
+    )
+    dataset: NVPanoptix3Dv2DatasetConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2DatasetConfig(),
+        description="Configurable parameters to construct the dataset for the NVPanoptix3Dv2 experiment.",
+    )
+    train: NVPanoptix3Dv2TrainExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2TrainExpConfig(),
+        description="Configurable parameters to construct the trainer for the NVPanoptix3Dv2 experiment.",
+    )
+    inference: NVPanoptix3Dv2InferenceExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2InferenceExpConfig(),
+        description="Configurable parameters to construct the inferencer for the NVPanoptix3Dv2 experiment.",
+    )
+    evaluate: NVPanoptix3Dv2EvaluateExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2EvaluateExpConfig(),
+        description="Configurable parameters to construct the evaluator for the NVPanoptix3Dv2 experiment.",
+    )
+    export: NVPanoptix3Dv2ExportExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2ExportExpConfig(),
+        description="Configurable parameters to construct the exporter for the NVPanoptix3Dv2 experiment.",
+    )
+    gen_trt_engine: NVPanoptix3Dv2GenTRTEngineExpConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2GenTRTEngineExpConfig(),
+        description="Configurable parameters to construct the TensorRT engine builder for a NVPanoptix3Dv2 experiment.",
+    )

--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/deploy.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/deploy.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema to deploy the model."""
+
+from dataclasses import dataclass
+
+from nvidia_tao_deploy.config.utils.types import (
+    DATACLASS_FIELD,
+    STR_FIELD
+)
+from nvidia_tao_deploy.config.common.common_config import (
+    GenTrtEngineConfig,
+    TrtConfig
+)
+
+
+@dataclass
+class NVPanoptix3Dv2TrtConfig(TrtConfig):
+    """Trt config."""
+
+    data_type: str = STR_FIELD(
+        value="FP32",
+        default_value="FP32",
+        description="The precision to be set for building the TensorRT engine.",
+        display_name="data type",
+        valid_options=",".join(["FP32", "FP16"])
+    )
+
+
+@dataclass
+class NVPanoptix3Dv2GenTRTEngineExpConfig(GenTrtEngineConfig):
+    """Gen TRT Engine experiment config."""
+
+    tensorrt: NVPanoptix3Dv2TrtConfig = DATACLASS_FIELD(
+        NVPanoptix3Dv2TrtConfig(),
+        description="Hyper parameters to configure the NVPanoptix3Dv2 TensorRT Engine builder.",
+        display_name="TensorRT hyper params.",
+    )

--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/evaluate.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/evaluate.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the evaluation."""
+
+from dataclasses import dataclass
+
+from nvidia_tao_deploy.config.common.common_config import EvaluateConfig
+from nvidia_tao_deploy.config.utils.types import FLOAT_FIELD
+
+
+@dataclass
+class NVPanoptix3Dv2EvaluateExpConfig(EvaluateConfig):
+    """NVPanoptix3Dv2 evaluation configuration."""
+
+    cls_threshold: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="class threshold",
+        description="Minimum class score for a query to enter panoptic post-processing.",
+    )
+    mask_threshold: float = FLOAT_FIELD(
+        value=0.25,
+        default_value=0.25,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="mask threshold",
+        description="Probability threshold binarizing the predicted masks.",
+    )
+    overlap_threshold: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="overlap threshold",
+        description="""
+        Minimum fraction of a segment that must survive occlusion by
+        higher-scoring segments for it to be kept.""",
+    )

--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/export.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/export.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for export."""
+
+from typing import Optional
+from dataclasses import dataclass
+
+from nvidia_tao_deploy.config.common.common_config import ExportConfig
+from nvidia_tao_deploy.config.utils.types import (
+    INT_FIELD,
+    STR_FIELD
+)
+
+
+@dataclass
+class NVPanoptix3Dv2ExportExpConfig(ExportConfig):
+    """NVPanoptix3Dv2 export ONNX experiment config."""
+
+    categories_json: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="categories json",
+        description="""
+        Path to a categories JSON (a list of :code:`{id, name, isthing}`
+        dicts) defining the vocabulary baked into the ONNX graph. Null uses
+        the dataset taxonomy.""",
+    )
+    num_views: int = INT_FIELD(
+        value=5,
+        default_value=5,
+        valid_min=2,
+        description="Number of views in the exported multi-view input tensor.",
+        display_name="number of views",
+    )

--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/inference.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/inference.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the inferencer."""
+
+from typing import Optional
+from dataclasses import dataclass
+
+from nvidia_tao_deploy.config.common.common_config import InferenceConfig
+from nvidia_tao_deploy.config.utils.types import (
+    BOOL_FIELD,
+    FLOAT_FIELD,
+    STR_FIELD
+)
+
+
+@dataclass
+class NVPanoptix3Dv2InferenceExpConfig(InferenceConfig):
+    """NVPanoptix3Dv2 inference configuration."""
+
+    cls_threshold: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="class threshold",
+        description="Minimum class score for a query to enter panoptic post-processing.",
+    )
+    mask_threshold: float = FLOAT_FIELD(
+        value=0.25,
+        default_value=0.25,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="mask threshold",
+        description="Probability threshold binarizing the predicted masks.",
+    )
+    overlap_threshold: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="overlap threshold",
+        description="""
+        Minimum fraction of a segment that must survive occlusion by
+        higher-scoring segments for it to be kept.""",
+    )
+    categories_json: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="categories json",
+        description="""
+        Path to a categories JSON (a list of :code:`{id, name, isthing}` dicts)
+        defining the open-vocabulary class list to predict against. Null uses
+        the dataset's own categories.""",
+    )
+    output_dir: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="output directory",
+        description="Directory for prediction artifacts. Null uses results_dir.",
+    )
+    save_full_point_cloud: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="save full point cloud",
+        description="""
+        Reasoning variant only. Save one sample-level NPZ containing the full
+        RGB point cloud and fused predicted segmentation mask. This is opt-in
+        because dense multi-view point clouds can consume substantial disk
+        space.
+        """,
+    )

--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/model.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/model.py
@@ -1,0 +1,536 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the model."""
+
+from typing import List, Optional
+from dataclasses import dataclass
+
+from nvidia_tao_deploy.config.utils.types import (
+    BOOL_FIELD,
+    DATACLASS_FIELD,
+    FLOAT_FIELD,
+    INT_FIELD,
+    LIST_FIELD,
+    STR_FIELD
+)
+
+
+@dataclass
+class MetricDepthHeadConfig:
+    """Metric scale head config."""
+
+    enable: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="enable metric depth head",
+        description="""
+        Flag to enable the metric-scale head. When enabled a single scene-level
+        log-scale is regressed from the pooled VGGT patch tokens and applied to
+        the relative depth and world points of every view.""",
+    )
+    feat_dim: int = INT_FIELD(
+        value=2048,
+        default_value=2048,
+        valid_min=1,
+        display_name="scene token dim",
+        description="Channel width of the pooled VGGT patch token fed to the metric-scale head.",
+    )
+    hidden_dims: List[int] = LIST_FIELD(
+        arrList=[256, 64],
+        default_value=[256, 64],
+        display_name="hidden dims",
+        description="Hidden widths of the metric-scale MLP.",
+    )
+    metric_context_views: int = INT_FIELD(
+        value=5,
+        default_value=5,
+        valid_min=1,
+        display_name="metric context views",
+        description="""
+        Number of leading views used to estimate the single scene scale. The
+        estimated scale is then applied to every inference view, including
+        views outside this context window.""",
+    )
+    predict_shift: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="predict depth shift",
+        description="""
+        Also regress an additive depth shift, so
+        :code:`d_metric = s * d_rel + b`. This config is used by the reasoning
+        variant; the panoptic builder always uses scale-only correction. The
+        shift lives in depth units and is never applied to 3D points.""",
+    )
+
+
+@dataclass
+class BackboneConfig:
+    """Backbone config."""
+
+    pretrained_backbone_path: str = STR_FIELD(
+        value="",
+        default_value="",
+        display_name="pretrained backbone path",
+        description="""
+        Path to the pretrained VGGT checkpoint. When empty the backbone falls
+        back to the :code:`facebook/VGGT-1B` weights from the model hub.""",
+    )
+    load_from_hf: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="load backbone from HF",
+        description="""
+        Fall back to the :code:`facebook/VGGT-1B` hub weights when
+        pretrained_backbone_path is unset. Keep this off so a missing or
+        unmounted commercial checkpoint fails loudly instead of silently
+        pulling non-commercial weights.""",
+    )
+    strict_load: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="strict backbone load",
+        description="Require the VGGT checkpoint to match the built heads exactly.",
+    )
+    metric_depth_head: MetricDepthHeadConfig = DATACLASS_FIELD(
+        MetricDepthHeadConfig(),
+        display_name="metric depth head",
+        description="Configuration hyper parameters for the metric-scale head.",
+    )
+
+
+@dataclass
+class FeatureFusionConfig:
+    """Feature fusion config."""
+
+    dino_dim: int = INT_FIELD(
+        value=1024,
+        default_value=1024,
+        valid_min=1,
+        display_name="dino dim",
+        description="Channel width of the DINOv2 token stream.",
+    )
+    vggt_dim: int = INT_FIELD(
+        value=2048,
+        default_value=2048,
+        valid_min=1,
+        display_name="vggt dim",
+        description="Channel width of the VGGT token stream.",
+    )
+    hidden_dim: int = INT_FIELD(
+        value=768,
+        default_value=768,
+        valid_min=1,
+        display_name="hidden dim",
+        description="Channel width of the fused token map.",
+        popular="yes",
+    )
+    num_heads: int = INT_FIELD(
+        value=12,
+        default_value=12,
+        valid_min=1,
+        display_name="number of heads",
+        description="Number of attention heads in the per-view spatial mixer.",
+    )
+    num_layers: int = INT_FIELD(
+        value=3,
+        default_value=3,
+        valid_min=0,
+        display_name="number of layers",
+        description="Number of blocks in the per-view spatial mixer.",
+    )
+    ff_dim_mult: int = INT_FIELD(
+        value=4,
+        default_value=4,
+        valid_min=1,
+        display_name="feedforward dim multiplier",
+        description="Feedforward expansion ratio inside each spatial-mixer block.",
+    )
+
+
+@dataclass
+class PanopticDecoderConfig:
+    """Panoptic decoder config."""
+
+    hidden_dim: int = INT_FIELD(
+        value=768,
+        default_value=768,
+        valid_min=1,
+        display_name="hidden dim",
+        description="Channel width of the decoder queries and memory.",
+        popular="yes",
+    )
+    mask_dim: int = INT_FIELD(
+        value=384,
+        default_value=384,
+        valid_min=1,
+        display_name="mask dim",
+        description="Channel width of the high-resolution mask features.",
+    )
+    ff_dim: int = INT_FIELD(
+        value=2048,
+        default_value=2048,
+        valid_min=1,
+        display_name="feedforward dim",
+        description="Width of the feedforward network in the mask transformer.",
+    )
+    num_queries: int = INT_FIELD(
+        value=200,
+        default_value=200,
+        valid_min=1,
+        display_name="number of queries",
+        description="Number of learned object queries.",
+        popular="yes",
+    )
+    num_heads: int = INT_FIELD(
+        value=8,
+        default_value=8,
+        valid_min=1,
+        display_name="number of heads",
+        description="Number of attention heads in the mask transformer.",
+    )
+    dec_layers: int = INT_FIELD(
+        value=6,
+        default_value=6,
+        valid_min=1,
+        display_name="decoder layers",
+        description="Number of mask-transformer decoder layers.",
+    )
+    fixed_vocab: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="fixed vocabulary",
+        description="""
+        Flag to encode the full class vocabulary once up front. The collator
+        then performs cache lookups instead of re-encoding text every step.""",
+    )
+    label_mode: str = STR_FIELD(
+        value="sigmoid",
+        default_value="sigmoid",
+        display_name="label mode",
+        description="Classification head activation used for open-vocabulary labels.",
+        valid_options=",".join(["sigmoid", "softmax"])
+    )
+    deep_supervision: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="deep supervision",
+        description="Flag to supervise the intermediate decoder layer outputs.",
+    )
+    enable_objectness: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="enable objectness",
+        description="""
+        Flag to enable the vocabulary-independent matched/unmatched query
+        confidence head.""",
+    )
+
+
+@dataclass
+class UpscalerConfig:
+    """LoftUp mask-feature upscaler config."""
+
+    input_dim: int = INT_FIELD(
+        value=768,
+        default_value=768,
+        valid_min=1,
+        display_name="input dim",
+        description="Channel width of the fused token map fed to the upscaler.",
+    )
+    dim: int = INT_FIELD(
+        value=384,
+        default_value=384,
+        valid_min=1,
+        display_name="output dim",
+        description="Channel width of the upscaled mask features.",
+    )
+    output_stride: int = INT_FIELD(
+        value=2,
+        default_value=2,
+        valid_min=1,
+        display_name="output stride",
+        description="Stride of the upscaled mask features relative to the input image.",
+    )
+    patch_size: int = INT_FIELD(
+        value=14,
+        default_value=14,
+        valid_min=1,
+        display_name="patch size",
+        description="Patch size of the token map consumed by the upscaler.",
+    )
+    color_feats: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="use color features",
+        description="Flag to condition the upscaler on the input RGB image.",
+    )
+    n_freqs: int = INT_FIELD(
+        value=20,
+        default_value=20,
+        valid_min=1,
+        display_name="number of frequencies",
+        description="Number of Fourier frequencies in the implicit featurizer.",
+    )
+    num_heads: int = INT_FIELD(
+        value=4,
+        default_value=4,
+        valid_min=1,
+        display_name="number of heads",
+        description="Number of attention heads in the upscaler cross-attention blocks.",
+    )
+    num_layers: int = INT_FIELD(
+        value=2,
+        default_value=2,
+        valid_min=1,
+        display_name="number of layers",
+        description="Number of upscaler cross-attention blocks.",
+    )
+
+
+@dataclass
+class PanopticVariantConfig:
+    """Architecture of the panoptic-segmentation variant."""
+
+    feature_fusion: FeatureFusionConfig = DATACLASS_FIELD(
+        FeatureFusionConfig(),
+        display_name="feature fusion",
+        description="Configuration hyper parameters for the DINOv2/VGGT feature fusion.",
+    )
+    panoptic_decoder: PanopticDecoderConfig = DATACLASS_FIELD(
+        PanopticDecoderConfig(),
+        display_name="panoptic decoder",
+        description="Configuration hyper parameters for the panoptic segmentation decoder.",
+    )
+    upscaler: UpscalerConfig = DATACLASS_FIELD(
+        UpscalerConfig(),
+        display_name="upscaler",
+        description="Configuration hyper parameters for the mask-feature upscaler.",
+    )
+
+
+@dataclass
+class LoraConfig:
+    """LoRA adapter config for the Qwen reasoner."""
+
+    r: int = INT_FIELD(
+        value=16,
+        default_value=16,
+        valid_min=1,
+        display_name="LoRA rank",
+        description="Rank of the LoRA update matrices.",
+    )
+    alpha: int = INT_FIELD(
+        value=32,
+        default_value=32,
+        valid_min=1,
+        display_name="LoRA alpha",
+        description="LoRA scaling factor.",
+    )
+    dropout: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="LoRA dropout",
+        description="Dropout applied inside the LoRA adapters.",
+    )
+
+
+@dataclass
+class QwenConfig:
+    """Qwen vision-language reasoner config."""
+
+    model_id: str = STR_FIELD(
+        value="Qwen/Qwen3-VL-4B-Instruct",
+        default_value="Qwen/Qwen3-VL-4B-Instruct",
+        display_name="Qwen model id",
+        description="Hugging Face model id or local directory for Qwen3-VL-4B.",
+    )
+    seg_token: str = STR_FIELD(
+        value="[SEG]",
+        default_value="[SEG]",
+        display_name="segmentation token",
+        description="Added token whose hidden state is projected into the SAM3 prompt space.",
+    )
+    freeze_vision: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="freeze vision tower",
+        description="Flag to freeze the Qwen vision tower.",
+    )
+    dtype: str = STR_FIELD(
+        value="bfloat16",
+        default_value="bfloat16",
+        display_name="dtype",
+        description="Compute dtype for the Qwen weights.",
+        valid_options=",".join(["float32", "bfloat16", "float16"])
+    )
+    attn_implementation: str = STR_FIELD(
+        value="sdpa",
+        default_value="sdpa",
+        display_name="attention implementation",
+        description="Attention kernel used by the Qwen backbone.",
+        valid_options=",".join(["sdpa", "eager", "flash_attention_2"])
+    )
+    use_lora: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="use LoRA",
+        description="Train LoRA adapters instead of the full Qwen weights.",
+    )
+    lora: LoraConfig = DATACLASS_FIELD(
+        LoraConfig(),
+        display_name="LoRA",
+        description="Hyper parameters for the LoRA adapters.",
+    )
+
+
+@dataclass
+class Sam3Config:
+    """Frozen SAM3 mask-decoder config."""
+
+    checkpoint: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="SAM3 checkpoint",
+        description="""
+        Path to a local SAM3 checkpoint. Null downloads the weights from the
+        hub when load_from_hf is set.""",
+    )
+    load_from_hf: bool = BOOL_FIELD(
+        value=True,
+        default_value=True,
+        display_name="load SAM3 from HF",
+        description="Download the SAM3 weights from the hub when no checkpoint is given.",
+    )
+    resolution: int = INT_FIELD(
+        value=1008,
+        default_value=1008,
+        valid_min=32,
+        display_name="SAM3 resolution",
+        description="Square resolution the input views are resized to for SAM3.",
+    )
+
+
+@dataclass
+class SamBridgeConfig:
+    """``[SEG]``-to-SAM3 prompt projector config."""
+
+    sam_prompt_dim: int = INT_FIELD(
+        value=256,
+        default_value=256,
+        valid_min=1,
+        display_name="SAM prompt dim",
+        description="Width of the SAM3 language-prompt tensor.",
+    )
+    hidden_dim: int = INT_FIELD(
+        value=4096,
+        default_value=4096,
+        valid_min=1,
+        display_name="projector hidden dim",
+        description="Hidden width of the ``[SEG]`` -> SAM prompt MLP.",
+    )
+    dropout: float = FLOAT_FIELD(
+        value=0.0,
+        default_value=0.0,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="projector dropout",
+        description="Dropout inside the projector MLP.",
+    )
+
+
+@dataclass
+class ReasoningVariantConfig:
+    """Architecture of the reasoning-segmentation variant."""
+
+    qwen: QwenConfig = DATACLASS_FIELD(
+        QwenConfig(),
+        display_name="Qwen reasoner",
+        description="Configuration hyper parameters for the Qwen VLM reasoner.",
+    )
+    sam3: Sam3Config = DATACLASS_FIELD(
+        Sam3Config(),
+        display_name="SAM3",
+        description="Configuration hyper parameters for the frozen SAM3 mask decoder.",
+    )
+    sam_bridge: SamBridgeConfig = DATACLASS_FIELD(
+        SamBridgeConfig(),
+        display_name="SAM bridge",
+        description="Configuration hyper parameters for the ``[SEG]`` prompt projector.",
+    )
+    point_mask_threshold: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="point mask threshold",
+        description="Foreground threshold applied to the SAM3 mask before lifting to 3D.",
+    )
+    point_conf_threshold: Optional[float] = FLOAT_FIELD(
+        value=None,
+        display_name="point confidence threshold",
+        description="""
+        Optional VGGT confidence gate on the lifted points. Null keeps every
+        geometrically valid point.""",
+    )
+
+
+@dataclass
+class NVPanoptix3Dv2ModelConfig:
+    """NVPanoptix3Dv2 model config.
+
+    Both variants share the frozen VGGT backbone and the metric scale head
+    under :code:`backbone`; :code:`model_type` selects which variant-specific
+    block is read and which Lightning module is built.
+    """
+
+    model_type: str = STR_FIELD(
+        value="panoptic",
+        default_value="panoptic",
+        display_name="model type",
+        description="""
+        Which NVPanoptix3Dv2 variant to build:
+        * :code:`panoptic`  -- open-vocabulary panoptic segmentation.
+        * :code:`reasoning` -- Qwen-driven reasoning segmentation.""",
+        valid_options=",".join(["panoptic", "reasoning"]),
+        popular="yes",
+    )
+    img_size: int = INT_FIELD(
+        value=518,
+        default_value=518,
+        valid_min=32,
+        display_name="image size",
+        description="Image size the VGGT backbone is instantiated for.",
+    )
+    patch_size: int = INT_FIELD(
+        value=14,
+        default_value=14,
+        valid_min=1,
+        display_name="patch size",
+        description="Patch size of the VGGT backbone.",
+    )
+    embed_dim: int = INT_FIELD(
+        value=1024,
+        default_value=1024,
+        valid_min=1,
+        display_name="embedding dim",
+        description="Token width of the VGGT backbone.",
+    )
+    backbone: BackboneConfig = DATACLASS_FIELD(
+        BackboneConfig(),
+        display_name="backbone",
+        description="""
+        Configuration hyper parameters for the frozen VGGT backbone and the
+        metric scale head. Shared by both variants.""",
+    )
+    panoptic: PanopticVariantConfig = DATACLASS_FIELD(
+        PanopticVariantConfig(),
+        display_name="panoptic variant",
+        description="Architecture of the panoptic variant. Read when model_type is panoptic.",
+    )
+    reasoning: ReasoningVariantConfig = DATACLASS_FIELD(
+        ReasoningVariantConfig(),
+        display_name="reasoning variant",
+        description="Architecture of the reasoning variant. Read when model_type is reasoning.",
+    )

--- a/nvidia_tao_deploy/config/nvpanoptix3d_v2/train.py
+++ b/nvidia_tao_deploy/config/nvpanoptix3d_v2/train.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration hyperparameter schema for the trainer."""
+
+from typing import Optional
+from dataclasses import dataclass
+
+from nvidia_tao_deploy.config.utils.types import (
+    BOOL_FIELD,
+    DATACLASS_FIELD,
+    FLOAT_FIELD,
+    INT_FIELD,
+    STR_FIELD
+)
+from nvidia_tao_deploy.config.common.common_config import TrainConfig
+
+
+@dataclass
+class MetricDepthLossConfig:
+    """Metric depth loss config."""
+
+    weight: float = FLOAT_FIELD(
+        value=5.0,
+        default_value=5.0,
+        valid_min=0.0,
+        display_name="metric depth weight",
+        description="Outer multiplier on the metric-depth loss. Set to 0 to disable.",
+    )
+    silog_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="SILog weight",
+        description="Weight of the scale-invariant log term.",
+    )
+    absrel_weight: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        valid_min=0.0,
+        display_name="AbsRel weight",
+        description="Weight of the auxiliary absolute-relative term. Set to 0 to disable.",
+    )
+    silog_lambda: float = FLOAT_FIELD(
+        value=0.85,
+        default_value=0.85,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="SILog lambda",
+        description="SILog variance-mixing constant.",
+    )
+    min_depth: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        math_cond="> 0.0",
+        display_name="min depth",
+        description="Lower bound of the supervised metric-depth range, in metres.",
+    )
+    max_depth: float = FLOAT_FIELD(
+        value=20.0,
+        default_value=20.0,
+        math_cond="> 0.0",
+        display_name="max depth",
+        description="Upper bound of the supervised metric-depth range, in metres.",
+    )
+
+
+@dataclass
+class PanopticLossConfig:
+    """Loss weights for the panoptic variant."""
+
+    class_weight: float = FLOAT_FIELD(
+        value=2.0,
+        default_value=2.0,
+        valid_min=0.0,
+        display_name="class loss coefficient",
+        description="Weight of the open-vocabulary classification loss.",
+        popular="yes",
+    )
+    rank_weight: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        display_name="rank loss coefficient",
+        description="""
+        Weight of the matched-query cross-entropy that trains the
+        one-label-per-query top-1 decision.""",
+    )
+    objectness_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="objectness loss coefficient",
+        description="Weight of the binary matched/unmatched query confidence loss.",
+    )
+    objectness_no_object_weight: float = FLOAT_FIELD(
+        value=0.1,
+        default_value=0.1,
+        valid_min=0.0,
+        display_name="objectness no-object coefficient",
+        description="Relative weight applied to the no-object objectness target.",
+    )
+    objectness_ignore_overlap_threshold: float = FLOAT_FIELD(
+        value=0.5,
+        default_value=0.5,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="objectness ignore overlap threshold",
+        description="""
+        Unmatched queries whose predicted mask lies at least this fraction on
+        ignored or crowd pixels receive no objectness target.""",
+    )
+    mask_weight: float = FLOAT_FIELD(
+        value=20.0,
+        default_value=20.0,
+        valid_min=0.0,
+        display_name="mask loss coefficient",
+        description="Weight of the point-sampled binary mask loss.",
+        popular="yes",
+    )
+    dice_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="dice loss coefficient",
+        description="Weight of the dice loss of the binary mask.",
+        popular="yes",
+    )
+    num_loss_points: int = INT_FIELD(
+        value=12288,
+        default_value=12288,
+        valid_min=1,
+        display_name="number of loss points",
+        description="Number of points sampled per mask for the mask and dice losses.",
+    )
+
+
+@dataclass
+class ReasoningLossConfig:
+    """Loss weights for the reasoning variant."""
+
+    text_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="text loss coefficient",
+        description="Weight of the Qwen next-token cross-entropy on the answer.",
+        popular="yes",
+    )
+    mask_weight: float = FLOAT_FIELD(
+        value=20.0,
+        default_value=20.0,
+        valid_min=0.0,
+        display_name="mask loss coefficient",
+        description="Weight of the SAM3 binary mask loss.",
+        popular="yes",
+    )
+    dice_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="dice loss coefficient",
+        description="Weight of the dice loss on the SAM3 mask.",
+        popular="yes",
+    )
+    score_weight: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="score loss coefficient",
+        description="Weight of the SAM3 query-selection score loss.",
+    )
+
+
+@dataclass
+class NVPanoptix3Dv2TrainExpConfig(TrainConfig):
+    """Train experiment config."""
+
+    accum_iter: int = INT_FIELD(
+        value=1,
+        default_value=1,
+        valid_min=1,
+        display_name="gradient accumulation iterations",
+        description="Number of batches accumulated before an optimizer step.",
+    )
+    lr: float = FLOAT_FIELD(
+        value=1.0e-4,
+        default_value=1.0e-4,
+        math_cond="> 0.0",
+        display_name="learning rate",
+        description="Peak learning rate after warmup.",
+    )
+    min_lr: float = FLOAT_FIELD(
+        value=1.0e-6,
+        default_value=1.0e-6,
+        valid_min=0.0,
+        display_name="minimum learning rate",
+        description="Floor of the cosine decay schedule.",
+    )
+    weight_decay: float = FLOAT_FIELD(
+        value=0.05,
+        default_value=0.05,
+        valid_min=0.0,
+        display_name="weight decay",
+        description="""
+        AdamW weight decay. Applied only to matrix and convolution weights;
+        norms, biases, scalar temperatures and embeddings get zero decay.""",
+    )
+    warmup_epochs: float = FLOAT_FIELD(
+        value=2.0,
+        default_value=2.0,
+        valid_min=0.0,
+        display_name="warmup epochs",
+        description="Length of the linear learning-rate warmup, in epochs.",
+    )
+    precision: str = STR_FIELD(
+        value="fp32",
+        default_value="fp32",
+        display_name="precision",
+        description="Precision to run the training on.",
+        valid_options=",".join(["fp32", "bf16", "fp16"])
+    )
+    is_dry_run: bool = BOOL_FIELD(
+        value=False,
+        default_value=False,
+        display_name="is dry run",
+        description="Flag to run the trainer in dry-run mode.",
+    )
+    clip_grad_norm: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        display_name="clip gradient norm",
+        description="Amount to clip the gradient by L2 norm. 0 disables clipping.",
+    )
+    val_check_interval: float = FLOAT_FIELD(
+        value=1.0,
+        default_value=1.0,
+        valid_min=0.0,
+        valid_max=1.0,
+        display_name="val check interval",
+        description="Fraction of a training epoch between validation runs.",
+    )
+    pretrained_model_path: Optional[str] = STR_FIELD(
+        value=None,
+        display_name="pretrained model path",
+        description="""
+        Checkpoint to warm-start the model weights from. Ignored when a resume
+        checkpoint is present, which always takes priority.""",
+    )
+    log_interval: int = INT_FIELD(
+        value=50,
+        default_value=50,
+        valid_min=1,
+        display_name="log interval",
+        description="Number of training steps between scalar logs.",
+    )
+    metric_depth: MetricDepthLossConfig = DATACLASS_FIELD(
+        MetricDepthLossConfig(),
+        display_name="metric depth loss",
+        description="""
+        Hyper parameters for the metric-depth loss. Shared by both variants,
+        which supervise the same metric scale head.""",
+    )
+    panoptic: PanopticLossConfig = DATACLASS_FIELD(
+        PanopticLossConfig(),
+        display_name="panoptic losses",
+        description="Loss weights for the panoptic variant. Read when model_type is panoptic.",
+    )
+    reasoning: ReasoningLossConfig = DATACLASS_FIELD(
+        ReasoningLossConfig(),
+        display_name="reasoning losses",
+        description="Loss weights for the reasoning variant. Read when model_type is reasoning.",
+    )

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/__init__.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 TensorRT deployment support."""

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/dataloader.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/dataloader.py
@@ -1,0 +1,365 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ScanNet++ data loader for NVPanoptix3Dv2 TensorRT inference."""
+
+import json
+import math
+import os
+import random
+
+import numpy as np
+from PIL import Image
+
+
+class NVPanoptix3Dv2DataLoader:
+    """Build deterministic multi-view batches from preprocessed ScanNet++.
+
+    The loader consumes the same ``all_metadata.npz`` representation as the
+    PyTorch model. Images are principal-point centered, resized with preserved
+    aspect ratio, padded white, converted to RGB ``[0, 1]``, and returned in
+    ``[B, S, 3, H, W]`` layout.
+
+    Args:
+        preprocessed_root: Directory containing ``all_metadata.npz``,
+            ``categories.json``, and one image directory per scene.
+        shape: TensorRT input shape ``[B, S, 3, H, W]``. A dynamic batch axis
+            may be given as ``-1`` when ``batch_size`` is specified.
+        dtype: NumPy dtype of the returned image tensor.
+        batch_size: Batch size used when ``shape[0]`` is dynamic.
+        pairs_per_scene: Number of deterministic samples drawn per scene.
+        seed: Base seed for pair and neighboring-view selection.
+        max_samples: Optional limit on the number of samples.
+    """
+
+    def __init__(
+        self,
+        preprocessed_root,
+        shape,
+        dtype=np.float32,
+        batch_size=None,
+        pairs_per_scene=1,
+        seed=42,
+        max_samples=None,
+    ):
+        self.preprocessed_root = os.path.realpath(
+            os.path.expanduser(str(preprocessed_root))
+        )
+        self.shape = tuple(int(dim) for dim in shape)
+        self.dtype = np.dtype(dtype)
+        if not np.issubdtype(self.dtype, np.floating):
+            raise ValueError(
+                f"NVPanoptix3Dv2 image dtype must be floating point, got {self.dtype}"
+            )
+        self.pairs_per_scene = int(pairs_per_scene)
+        self.seed = int(seed)
+        self.batch_index = 0
+
+        self.validate_input_shape(batch_size)
+        self.load_metadata()
+        self.build_pair_indices()
+
+        self.num_samples = len(self.scenes) * self.pairs_per_scene
+        if max_samples is not None:
+            max_samples = int(max_samples)
+            if max_samples <= 0:
+                raise ValueError(
+                    f"max_samples must be positive, got {max_samples}"
+                )
+            self.num_samples = min(self.num_samples, max_samples)
+        self.num_batches = math.ceil(self.num_samples / self.batch_size)
+
+    def validate_input_shape(self, batch_size):
+        """Validate and resolve the TensorRT input dimensions."""
+        if len(self.shape) != 5:
+            raise ValueError(
+                "NVPanoptix3Dv2 input shape must be [B, S, 3, H, W], "
+                f"got {self.shape}"
+            )
+        shape_batch, self.num_views, channels, self.height, self.width = self.shape
+        if channels != 3:
+            raise ValueError(
+                f"NVPanoptix3Dv2 expects three RGB channels, got {channels}"
+            )
+        if self.num_views < 2 or self.height <= 0 or self.width <= 0:
+            raise ValueError(
+                "View count, height, and width must be positive static "
+                f"dimensions, got {self.shape}"
+            )
+        if shape_batch == -1:
+            if batch_size is None or int(batch_size) <= 0:
+                raise ValueError(
+                    "A positive batch_size is required for a dynamic input shape"
+                )
+            self.batch_size = int(batch_size)
+            self.dynamic_batch = True
+        elif shape_batch > 0:
+            if batch_size is not None and int(batch_size) != shape_batch:
+                raise ValueError(
+                    f"batch_size={batch_size} conflicts with shape {self.shape}"
+                )
+            self.batch_size = shape_batch
+            self.dynamic_batch = False
+        else:
+            raise ValueError(
+                f"Batch dimension must be positive or -1, got {shape_batch}"
+            )
+        if self.pairs_per_scene <= 0:
+            raise ValueError(
+                f"pairs_per_scene must be positive, got {self.pairs_per_scene}"
+            )
+
+    def load_metadata(self):
+        """Load and validate the ScanNet++ metadata and class vocabulary."""
+        metadata_path = os.path.join(
+            self.preprocessed_root, "all_metadata.npz"
+        )
+        categories_path = os.path.join(
+            self.preprocessed_root, "categories.json"
+        )
+        for path in (metadata_path, categories_path):
+            if not os.path.isfile(path):
+                raise FileNotFoundError(path)
+
+        with open(categories_path, "r", encoding="utf-8") as handle:
+            self.categories = json.load(handle)
+        if not isinstance(self.categories, list) or not all(
+            isinstance(category, dict) and category.get("name")
+            for category in self.categories
+        ):
+            raise ValueError(
+                f"Invalid category list in {categories_path}"
+            )
+        self.classes = [category["name"] for category in self.categories]
+
+        with np.load(metadata_path, allow_pickle=True) as metadata:
+            required = {"scenes", "sceneids", "images", "intrinsics", "pairs"}
+            missing = required.difference(metadata.files)
+            if missing:
+                raise ValueError(
+                    f"Missing metadata arrays in {metadata_path}: "
+                    f"{', '.join(sorted(missing))}"
+                )
+            scenes = np.asarray(metadata["scenes"])
+            self.scene_ids = metadata["sceneids"].astype(np.int64)
+            images = np.asarray(metadata["images"])
+            self.intrinsics = metadata["intrinsics"].astype(np.float32)
+            pairs = np.asarray(metadata["pairs"])
+        self.scenes = [str(scene) for scene in scenes]
+        self.image_ids = [str(image) for image in images]
+
+        image_count = len(self.image_ids)
+        if not self.scenes or image_count == 0:
+            raise ValueError(f"Empty ScanNet++ metadata in {metadata_path}")
+        if not (
+            len(self.scene_ids) == image_count == len(self.intrinsics)
+        ):
+            raise ValueError(
+                "sceneids, images, and intrinsics must have equal lengths"
+            )
+        if pairs.ndim != 2 or pairs.shape[1] < 2:
+            raise ValueError(
+                f"pairs must have shape [N, >=2], got {pairs.shape}"
+            )
+        self.pairs = pairs[:, :2].astype(np.int64)
+
+    def build_pair_indices(self):
+        """Build per-image neighbors and per-scene pair lookup tables."""
+        image_count = len(self.image_ids)
+        self.pairs_per_image = [set() for _ in range(image_count)]
+        self.scene_pair_indices = [[] for _ in self.scenes]
+        for pair_index, (first, second) in enumerate(self.pairs):
+            if not (
+                0 <= first < image_count and 0 <= second < image_count
+            ):
+                raise ValueError(
+                    f"Pair {pair_index} contains invalid indices: "
+                    f"{first}, {second}"
+                )
+            first_scene = int(self.scene_ids[first])
+            second_scene = int(self.scene_ids[second])
+            if first_scene != second_scene:
+                raise ValueError(
+                    f"Pair {pair_index} crosses ScanNet++ scenes"
+                )
+            if not 0 <= first_scene < len(self.scenes):
+                raise ValueError(
+                    f"Image {first} has invalid scene index {first_scene}"
+                )
+            self.pairs_per_image[first].add(int(second))
+            self.pairs_per_image[second].add(int(first))
+            self.scene_pair_indices[first_scene].append(pair_index)
+
+        empty_scenes = [
+            self.scenes[index]
+            for index, pair_indices in enumerate(self.scene_pair_indices)
+            if not pair_indices
+        ]
+        if empty_scenes:
+            raise ValueError(
+                "Every scene must contain at least one pair; missing for: " +
+                ", ".join(empty_scenes)
+            )
+
+    def scene_directory(self, image_index):
+        """Return the scene directory for an image metadata index."""
+        scene_index = int(self.scene_ids[image_index])
+        return os.path.join(
+            self.preprocessed_root, self.scenes[scene_index]
+        )
+
+    def image_path(self, image_index):
+        """Return the RGB path for an image metadata index."""
+        return os.path.join(
+            self.scene_directory(image_index),
+            "images",
+            f"{self.image_ids[image_index]}.jpg",
+        )
+
+    def select_views(self, first, second, rng):
+        """Select the deterministic multi-view tuple around an anchor pair."""
+        selected = [int(first), int(second)]
+        selected_set = set(selected)
+        candidates = sorted(
+            self.pairs_per_image[first] | self.pairs_per_image[second]
+        )
+        rng.shuffle(candidates)
+        for candidate in candidates:
+            if len(selected) >= self.num_views:
+                break
+            if candidate not in selected_set:
+                selected.append(candidate)
+                selected_set.add(candidate)
+        while len(selected) < self.num_views:
+            selected.append(selected[len(selected) % len(selected)])
+        return selected[:self.num_views]
+
+    def preprocess_image(self, image_index):
+        """Load one view and reproduce the PyTorch spatial preprocessing."""
+        path = self.image_path(image_index)
+        if not os.path.isfile(path):
+            raise FileNotFoundError(path)
+
+        with Image.open(path) as source:
+            image = source.convert("RGB")
+        intrinsics = self.intrinsics[image_index].copy()
+        image_width, image_height = image.size
+        center_x = int(round(float(intrinsics[0, 2])))
+        center_y = int(round(float(intrinsics[1, 2])))
+        margin_x = min(center_x, image_width - center_x)
+        margin_y = min(center_y, image_height - center_y)
+        if margin_x <= 0 or margin_y <= 0:
+            raise ValueError(
+                f"Invalid principal point ({center_x}, {center_y}) for "
+                f"image {path} with size {image.size}"
+            )
+
+        left, top = center_x - margin_x, center_y - margin_y
+        right, bottom = center_x + margin_x, center_y + margin_y
+        image = image.crop((left, top, right, bottom))
+        intrinsics[0, 2] -= left
+        intrinsics[1, 2] -= top
+
+        crop_width, crop_height = image.size
+        scale = min(
+            self.width / crop_width,
+            self.height / crop_height,
+        )
+        resized_width = max(
+            1, min(self.width, round(crop_width * scale))
+        )
+        resized_height = max(
+            1, min(self.height, round(crop_height * scale))
+        )
+        image = image.resize(
+            (resized_width, resized_height), Image.LANCZOS
+        )
+        intrinsics[0, :] *= resized_width / crop_width
+        intrinsics[1, :] *= resized_height / crop_height
+
+        pad_left = (self.width - resized_width) // 2
+        pad_top = (self.height - resized_height) // 2
+        canvas = Image.new(
+            "RGB", (self.width, self.height), (255, 255, 255)
+        )
+        canvas.paste(image, (pad_left, pad_top))
+        intrinsics[0, 2] += pad_left
+        intrinsics[1, 2] += pad_top
+
+        image_array = np.asarray(canvas, dtype=np.float32) / 255.0
+        image_array = image_array.transpose(2, 0, 1).astype(
+            self.dtype, copy=False
+        )
+        return image_array, intrinsics, path
+
+    def get_sample(self, sample_index):
+        """Load one deterministic scene sample and its identifying metadata."""
+        if not 0 <= sample_index < self.num_samples:
+            raise IndexError(sample_index)
+        scene_index = sample_index % len(self.scenes)
+        rng = random.Random(self.seed + sample_index)
+        pair_index = rng.choice(self.scene_pair_indices[scene_index])
+        first, second = self.pairs[pair_index]
+        view_indices = self.select_views(first, second, rng)
+
+        images = []
+        adjusted_intrinsics = []
+        image_paths = []
+        for image_index in view_indices:
+            image, intrinsics, path = self.preprocess_image(image_index)
+            images.append(image)
+            adjusted_intrinsics.append(intrinsics)
+            image_paths.append(path)
+
+        sample = np.stack(images)
+        metadata = {
+            "scene_id": self.scenes[scene_index],
+            "view_ids": [self.image_ids[index] for index in view_indices],
+            "image_paths": image_paths,
+            "intrinsics": np.stack(adjusted_intrinsics),
+            "input_size": (self.height, self.width),
+        }
+        return sample, metadata
+
+    def __len__(self):
+        """Return the number of TensorRT batches."""
+        return self.num_batches
+
+    def __iter__(self):
+        """Reset batch iteration."""
+        self.batch_index = 0
+        return self
+
+    def __next__(self):
+        """Return one image batch and metadata for its real samples."""
+        if self.batch_index >= self.num_batches:
+            raise StopIteration
+
+        start = self.batch_index * self.batch_size
+        stop = min(start + self.batch_size, self.num_samples)
+        output_batch_size = (
+            stop - start if self.dynamic_batch else self.batch_size
+        )
+        batch = np.zeros(
+            (
+                output_batch_size,
+                self.num_views,
+                3,
+                self.height,
+                self.width,
+            ),
+            dtype=self.dtype,
+        )
+        metadata = []
+        for batch_offset, sample_index in enumerate(range(start, stop)):
+            batch[batch_offset], sample_metadata = self.get_sample(sample_index)
+            metadata.append(sample_metadata)
+        self.batch_index += 1
+        return batch, metadata
+
+    def get_batch(self):
+        """Return an iterator over ``(images, metadata)`` batches."""
+        return iter(self)
+
+
+__all__ = ["NVPanoptix3Dv2DataLoader"]

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/engine_builder.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/engine_builder.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT engine builder for the NVPanoptix3Dv2 panoptic variant."""
+
+import logging
+
+from nvidia_tao_deploy.cv.nvpanoptix3d_v2.onnx_sanitizer import (
+    prepare_onnx_for_tensorrt,
+)
+from nvidia_tao_deploy.engine.builder import EngineBuilder
+
+
+logger = logging.getLogger(__name__)
+
+INPUT_NAME = "images"
+REQUIRED_OUTPUT_NAMES = frozenset(("pred_logits", "pred_masks"))
+
+
+class NVPanoptix3Dv2EngineBuilder(EngineBuilder):
+    """Parse and build the exported NVPanoptix3Dv2 panoptic ONNX graph.
+
+    The shared :class:`EngineBuilder` owns TensorRT parsing, optimization
+    profiles, precision selection, timing caches, and serialization. This
+    specialization protects that generic path with the NVPanoptix3Dv2 export
+    contract: one ``images`` input in ``[B, S, 3, H, W]`` layout, with only the
+    batch axis allowed to be dynamic, and the two required panoptic outputs.
+    """
+
+    def create_network(self, model_path, file_format="onnx"):
+        """Parse an ONNX graph and validate the panoptic tensor interface.
+
+        Args:
+            model_path: Path to the ONNX graph. External weight data is
+                resolved by TensorRT relative to this file.
+            file_format: Must be ``"onnx"``.
+
+        Raises:
+            ValueError: If the graph does not match the panoptic export
+                contract.
+        """
+        if str(file_format).lower() != "onnx":
+            raise ValueError("NVPanoptix3Dv2 deployment supports ONNX input only.")
+
+        report = prepare_onnx_for_tensorrt(model_path)
+        logger.info(
+            "Building the panoptic TensorRT engine from sanitized graph %s. "
+            "Derived metric outputs removed from the engine: %s",
+            report.output_path,
+            ", ".join(sorted(report.dropped_outputs)) or "none",
+        )
+        super().create_network(report.output_path, file_format="onnx")
+        self.validate_panoptic_network()
+
+    def validate_panoptic_network(self):
+        """Validate input layout and required output names after ONNX parsing."""
+        if self.network.num_inputs != 1:
+            raise ValueError(
+                "NVPanoptix3Dv2 panoptic ONNX must have exactly one input "
+                f"named '{INPUT_NAME}', but parsed {self.network.num_inputs}."
+            )
+
+        model_input = self.network.get_input(0)
+        if model_input.name != INPUT_NAME:
+            raise ValueError(
+                "NVPanoptix3Dv2 panoptic ONNX input must be named "
+                f"'{INPUT_NAME}', got '{model_input.name}'."
+            )
+
+        input_shape = tuple(int(dim) for dim in model_input.shape)
+        if len(input_shape) != 5:
+            raise ValueError(
+                "NVPanoptix3Dv2 panoptic ONNX input must have rank 5 in "
+                f"[B, S, 3, H, W] layout, got shape {input_shape}."
+            )
+
+        batch, num_views, channels, height, width = input_shape
+        if batch == 0 or batch < -1:
+            raise ValueError(
+                "NVPanoptix3Dv2 batch dimension must be a positive static "
+                f"value or -1, got {batch}."
+            )
+        if num_views < 2:
+            raise ValueError(
+                "NVPanoptix3Dv2 exports require at least two static views; "
+                f"got {num_views} in shape {input_shape}."
+            )
+        if channels != 3:
+            raise ValueError(
+                "NVPanoptix3Dv2 expects three RGB channels at input axis 2; "
+                f"got {channels} in shape {input_shape}."
+            )
+        if height <= 0 or width <= 0:
+            raise ValueError(
+                "NVPanoptix3Dv2 exports require static positive spatial "
+                f"dimensions; got {height}x{width}."
+            )
+
+        output_names = {
+            self.network.get_output(index).name
+            for index in range(self.network.num_outputs)
+        }
+        missing_outputs = REQUIRED_OUTPUT_NAMES - output_names
+        if missing_outputs:
+            raise ValueError(
+                "The ONNX graph is not an NVPanoptix3Dv2 panoptic export; "
+                "missing required output(s): " + ", ".join(sorted(missing_outputs))
+            )
+
+        self.num_views = num_views
+        self.input_height = height
+        self.input_width = width
+        logger.info(
+            "Validated NVPanoptix3Dv2 panoptic graph: input %s, outputs %s",
+            input_shape,
+            ", ".join(sorted(output_names)),
+        )

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/entrypoint/__init__.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/entrypoint/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 deployment entrypoint package."""

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/entrypoint/nvpanoptix3d_v2.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/entrypoint/nvpanoptix3d_v2.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Command-line entrypoint for NVPanoptix3Dv2 deployment tasks."""
+
+import argparse
+
+from nvidia_tao_deploy.cv.common.entrypoint.entrypoint_hydra import (
+    command_line_parser,
+    get_subtasks,
+    launch,
+)
+from nvidia_tao_deploy.cv.nvpanoptix3d_v2 import scripts
+
+
+def get_subtask_list():
+    """Return deployment subtasks discovered in the scripts package."""
+    return get_subtasks(scripts)
+
+
+def main():
+    """Parse the command line and launch an NVPanoptix3Dv2 subtask."""
+    parser = argparse.ArgumentParser(
+        "nvpanoptix3d_v2",
+        add_help=True,
+        description="Deploy the NVPanoptix3Dv2 panoptic model",
+    )
+    subtasks = get_subtask_list()
+    args, unknown_args = command_line_parser(parser, subtasks)
+    launch(vars(args), unknown_args, subtasks, network="nvpanoptix3d_v2")
+
+
+if __name__ == "__main__":
+    main()

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/inferencer.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/inferencer.py
@@ -1,0 +1,394 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TensorRT inference and panoptic postprocessing for NVPanoptix3Dv2."""
+
+import numpy as np
+
+from nvidia_tao_deploy.inferencer.trt_inferencer import TRTInferencer
+from nvidia_tao_deploy.inferencer.utils import do_inference
+
+
+INPUT_NAME = "images"
+REQUIRED_OUTPUT_NAMES = frozenset(("pred_logits", "pred_masks"))
+
+
+def sigmoid(values):
+    """Return a numerically stable NumPy sigmoid."""
+    values = np.asarray(values)
+    return 1.0 / (1.0 + np.exp(-np.clip(values, -80.0, 80.0)))
+
+
+def resize_masks(mask_probabilities, target_hw):
+    """Resize ``[B, S, Q, H, W]`` masks with linear interpolation."""
+    mask_probabilities = np.asarray(mask_probabilities)
+    if mask_probabilities.ndim != 5:
+        raise ValueError(
+            "mask_probabilities must have shape [B,S,Q,H,W], got "
+            f"{mask_probabilities.shape}"
+        )
+    target_height, target_width = (int(value) for value in target_hw)
+    if target_height <= 0 or target_width <= 0:
+        raise ValueError(
+            f"target_hw must contain positive dimensions, got {target_hw}"
+        )
+    height, width = mask_probabilities.shape[-2:]
+    if height <= 0 or width <= 0:
+        raise ValueError(
+            "Mask height and width must be positive, got "
+            f"{mask_probabilities.shape}"
+        )
+    if (height, width) == (target_height, target_width):
+        return mask_probabilities
+    horizontal_positions = (
+        (np.arange(target_width, dtype=np.float32) + 0.5) *
+        width / target_width - 0.5
+    )
+    left_indices = np.floor(horizontal_positions).astype(np.int64)
+    right_indices = left_indices + 1
+    horizontal_weights = horizontal_positions - left_indices
+    left_indices = np.clip(left_indices, 0, width - 1)
+    right_indices = np.clip(right_indices, 0, width - 1)
+    vertical_positions = (
+        (np.arange(target_height, dtype=np.float32) + 0.5) *
+        height / target_height - 0.5
+    )
+    top_indices = np.floor(vertical_positions).astype(np.int64)
+    bottom_indices = top_indices + 1
+    vertical_weights = vertical_positions - top_indices
+    top_indices = np.clip(top_indices, 0, height - 1)
+    bottom_indices = np.clip(bottom_indices, 0, height - 1)
+    vertical_weights = vertical_weights.reshape(1, target_height, 1)
+
+    batch_size, num_views, num_queries = mask_probabilities.shape[:3]
+    resized = np.empty(
+        (batch_size, num_views, num_queries, target_height, target_width),
+        dtype=np.float32,
+    )
+    for batch_index in range(batch_size):
+        for view_index in range(num_views):
+            masks = mask_probabilities[batch_index, view_index].astype(
+                np.float32, copy=False
+            )
+            left_values = masks[..., left_indices]
+            horizontal = left_values + (
+                masks[..., right_indices] - left_values
+            ) * horizontal_weights
+            top_values = horizontal[..., top_indices, :]
+            resized[batch_index, view_index] = top_values + (
+                horizontal[..., bottom_indices, :] - top_values
+            ) * vertical_weights
+    return resized
+
+
+def postprocess_panoptic(
+    outputs,
+    target_hw,
+    label_mode="sigmoid",
+    cls_threshold=0.1,
+    mask_threshold=0.25,
+    overlap_threshold=0.5,
+):
+    """Convert named TensorRT outputs into multi-view panoptic maps.
+
+    Args:
+        outputs: Mapping containing ``pred_logits`` and ``pred_masks``, plus
+            optional ``pred_objectness``.
+        target_hw: Output ``(height, width)``.
+        label_mode: Classification activation, ``sigmoid`` or ``softmax``.
+        cls_threshold: Minimum query confidence.
+        mask_threshold: Per-pixel mask probability threshold.
+        overlap_threshold: Minimum retained-to-original mask area ratio.
+
+    Returns:
+        One dictionary per batch sample. Each dictionary contains an int32
+        ``pan`` array ``[S, H, W]`` and a ``segments_info`` list.
+    """
+    missing = REQUIRED_OUTPUT_NAMES.difference(outputs)
+    if missing:
+        raise KeyError(
+            "Missing TensorRT panoptic output(s): " +
+            ", ".join(sorted(missing))
+        )
+    if label_mode not in {"sigmoid", "softmax"}:
+        raise ValueError(
+            f"label_mode must be 'sigmoid' or 'softmax', got {label_mode!r}"
+        )
+
+    mask_logits = np.asarray(outputs["pred_masks"])
+    class_logits = np.asarray(outputs["pred_logits"])
+    if mask_logits.ndim != 5 or class_logits.ndim != 3:
+        raise ValueError(
+            "Expected pred_masks [B,S,Q,H,W] and pred_logits [B,Q,C], "
+            f"got {mask_logits.shape} and {class_logits.shape}"
+        )
+    batch_size, num_views, num_queries = mask_logits.shape[:3]
+    if class_logits.shape[:2] != (batch_size, num_queries):
+        raise ValueError(
+            "pred_logits and pred_masks batch/query dimensions disagree: "
+            f"{class_logits.shape} vs {mask_logits.shape}"
+        )
+
+    objectness = outputs.get("pred_objectness")
+    if objectness is not None:
+        objectness = np.asarray(objectness)
+        if objectness.shape != (batch_size, num_queries):
+            raise ValueError(
+                "pred_objectness must have shape [B,Q], got "
+                f"{objectness.shape}"
+            )
+        objectness = sigmoid(objectness)
+
+    mask_probabilities = resize_masks(sigmoid(mask_logits), target_hw)
+    target_height, target_width = mask_probabilities.shape[-2:]
+    results = []
+    for batch_index in range(batch_size):
+        logits = class_logits[batch_index]
+        if label_mode == "sigmoid":
+            probabilities = sigmoid(logits)
+            labels = probabilities.argmax(axis=-1)
+            scores = probabilities[
+                np.arange(num_queries), labels
+            ]
+            if objectness is not None:
+                scores = scores * objectness[batch_index]
+            keep = scores > cls_threshold
+        else:
+            shifted = logits - logits.max(axis=-1, keepdims=True)
+            probabilities = np.exp(shifted)
+            probabilities /= probabilities.sum(axis=-1, keepdims=True)
+            labels = probabilities.argmax(axis=-1)
+            scores = probabilities[
+                np.arange(num_queries), labels
+            ]
+            if objectness is not None:
+                scores = scores * objectness[batch_index]
+            no_object_class = class_logits.shape[-1] - 1
+            keep = (labels != no_object_class) & (scores > cls_threshold)
+
+        kept_scores = scores[keep]
+        kept_labels = labels[keep]
+        kept_masks = mask_probabilities[batch_index][:, keep].transpose(
+            1, 0, 2, 3
+        )
+        panoptic_map = np.zeros(
+            (num_views, target_height, target_width), dtype=np.int32
+        )
+        segments_info = []
+        if kept_masks.shape[0] == 0:
+            results.append(
+                {"pan": panoptic_map, "segments_info": segments_info}
+            )
+            continue
+
+        weighted_masks = kept_scores[:, None, None, None] * kept_masks
+        assigned_queries = weighted_masks.argmax(axis=0)
+        for query_index, (category_id, score) in enumerate(
+            zip(kept_labels, kept_scores)
+        ):
+            original_area = int((kept_masks[query_index] >= 0.5).sum())
+            mask = (
+                (assigned_queries == query_index) &
+                (kept_masks[query_index] >= mask_threshold)
+            )
+            mask_area = int(mask.sum())
+            if (
+                mask_area == 0 or
+                original_area == 0 or
+                mask_area / original_area < overlap_threshold
+            ):
+                continue
+            segment_id = len(segments_info) + 1
+            panoptic_map[mask] = segment_id
+            segments_info.append(
+                {
+                    "id": segment_id,
+                    "category_id": int(category_id),
+                    "score": float(score),
+                    "area": mask_area,
+                }
+            )
+        results.append(
+            {"pan": panoptic_map, "segments_info": segments_info}
+        )
+    return results
+
+
+def outputs_to_dict(outputs):
+    """Reshape TensorRT host buffers and key them by output tensor name."""
+    result = {}
+    for output in outputs:
+        shape = tuple(int(dim) for dim in output.numpy_shape)
+        volume = int(np.prod(shape))
+        if volume <= 0 or output.host.size < volume:
+            raise ValueError(
+                f"Invalid runtime shape {shape} for output {output.name}"
+            )
+        result[output.name] = np.reshape(output.host[:volume], shape)
+    return result
+
+
+class NVPanoptix3Dv2Inferencer(TRTInferencer):
+    """Execute an NVPanoptix3Dv2 panoptic TensorRT engine."""
+
+    def __init__(
+        self,
+        engine_path,
+        input_shape=None,
+        batch_size=None,
+        data_format="channel_first",
+    ):
+        """Load the engine and allocate its input and output buffers."""
+        if data_format != "channel_first":
+            raise ValueError(
+                "NVPanoptix3Dv2 uses [B,S,3,H,W] channel-first input"
+            )
+        if input_shape is None and batch_size is None:
+            batch_size = 1
+        if input_shape is not None:
+            input_shape = tuple(int(dim) for dim in input_shape)
+            if len(input_shape) != 5 or input_shape[0] <= 0:
+                raise ValueError(
+                    "input_shape must be a resolved [B,S,3,H,W] shape, got "
+                    f"{input_shape}"
+                )
+            if batch_size is not None and int(batch_size) != input_shape[0]:
+                raise ValueError(
+                    f"batch_size={batch_size} conflicts with input_shape "
+                    f"{input_shape}"
+                )
+            self.allocated_batch_size = input_shape[0]
+        else:
+            self.allocated_batch_size = int(batch_size)
+            if self.allocated_batch_size <= 0:
+                raise ValueError(
+                    f"batch_size must be positive, got {batch_size}"
+                )
+        super().__init__(
+            engine_path,
+            input_shape=input_shape,
+            batch_size=batch_size,
+            data_format=data_format,
+            reshape=False,
+        )
+        if len(self.input_tensors) != 1:
+            raise ValueError(
+                "NVPanoptix3Dv2 requires exactly one TensorRT input"
+            )
+        input_tensor = self.input_tensors[0]
+        if input_tensor.tensor_name != INPUT_NAME:
+            raise ValueError(
+                f"NVPanoptix3Dv2 input must be '{INPUT_NAME}', got "
+                f"'{input_tensor.tensor_name}'"
+            )
+        if len(input_tensor.tensor_shape) != 5:
+            raise ValueError(
+                "NVPanoptix3Dv2 input must have shape [B,S,3,H,W], got "
+                f"{input_tensor.tensor_shape}"
+            )
+        output_names = {
+            output.tensor_name for output in self.output_tensors
+        }
+        missing = REQUIRED_OUTPUT_NAMES.difference(output_names)
+        if missing:
+            raise ValueError(
+                "Engine is missing required output(s): " +
+                ", ".join(sorted(missing))
+            )
+
+    def validate_images(self, images):
+        """Validate an image batch against the engine input contract."""
+        images = np.asarray(images)
+        if images.ndim != 5:
+            raise ValueError(
+                f"images must have shape [B,S,3,H,W], got {images.shape}"
+            )
+        engine_shape = tuple(self.input_tensors[0].tensor_shape)
+        allocated_batch_size = getattr(
+            self, "allocated_batch_size", images.shape[0]
+        )
+        if images.shape[0] > allocated_batch_size:
+            raise ValueError(
+                f"Batch size {images.shape[0]} exceeds the allocated TensorRT "
+                f"batch size {allocated_batch_size}"
+            )
+        for axis, (actual, expected) in enumerate(
+            zip(images.shape, engine_shape)
+        ):
+            if expected > 0 and actual != expected:
+                raise ValueError(
+                    f"images axis {axis} must be {expected}, got {actual}"
+                )
+        profile = getattr(
+            self.input_tensors[0], "optimization_profile", None
+        )
+        if profile is not None:
+            minimum, _, maximum = profile
+            for axis, actual in enumerate(images.shape):
+                if not minimum[axis] <= actual <= maximum[axis]:
+                    raise ValueError(
+                        f"images axis {axis}={actual} is outside TensorRT "
+                        f"profile [{minimum[axis]}, {maximum[axis]}]"
+                    )
+        return np.ascontiguousarray(images)
+
+    def infer(self, images):
+        """Execute one preprocessed ``[B,S,3,H,W]`` image batch.
+
+        Returns:
+            Dictionary of NumPy arrays keyed by TensorRT output name.
+        """
+        images = self.validate_images(images)
+        input_tensor = self.input_tensors[0]
+        if getattr(input_tensor, "optimization_profile", None) is not None:
+            accepted = self.context.set_input_shape(
+                input_tensor.tensor_name, tuple(images.shape)
+            )
+            if accepted is False:
+                raise ValueError(
+                    f"TensorRT rejected input shape {images.shape}"
+                )
+
+        self._copy_input_to_host([images])
+        raw_outputs = do_inference(
+            self.context,
+            bindings=self.bindings,
+            inputs=self.inputs,
+            outputs=self.outputs,
+            stream=self.stream,
+            batch_size=images.shape[0],
+            execute_v2=self.execute_async,
+            return_raw=True,
+        )
+        for output in raw_outputs:
+            output.numpy_shape = tuple(
+                int(dim)
+                for dim in self.context.get_tensor_shape(output.name)
+            )
+        return outputs_to_dict(raw_outputs)
+
+    @staticmethod
+    def postprocess(
+        outputs,
+        target_hw,
+        label_mode="sigmoid",
+        cls_threshold=0.1,
+        mask_threshold=0.25,
+        overlap_threshold=0.5,
+    ):
+        """Run panoptic postprocessing on named raw engine outputs."""
+        return postprocess_panoptic(
+            outputs,
+            target_hw=target_hw,
+            label_mode=label_mode,
+            cls_threshold=cls_threshold,
+            mask_threshold=mask_threshold,
+            overlap_threshold=overlap_threshold,
+        )
+
+
+__all__ = [
+    "NVPanoptix3Dv2Inferencer",
+    "outputs_to_dict",
+    "postprocess_panoptic",
+]

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/onnx_sanitizer.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/onnx_sanitizer.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prepare NVPanoptix3Dv2 panoptic ONNX graphs for TensorRT.
+
+The PyTorch export contains two constructs that are valid ONNX but unsuitable
+for the TensorRT panoptic engine:
+
+* The metric-scale head sorts every image pixel to calculate quantiles. At the
+  exported 518x518 resolution that becomes TopK with K=268324, beyond
+  TensorRT's TopK limit. Metric outputs are derived from raw geometry, so the
+  TensorRT graph keeps ``depth``, ``world_points`` and ``pose_enc`` and leaves
+  ``metric_depth``, ``metric_points`` and ``intrinsics`` to postprocessing.
+* The mask decoder uses advanced in-place indexing to clear fully masked
+  attention rows. PyTorch lowers it through NonZero and ScatterND with a
+  data-dependent update count. It is rewritten to an equivalent broadcast
+  Where operation.
+
+The source ONNX graph is never overwritten. A small derived protobuf is saved
+beside it so all relative external-weight references remain valid.
+"""
+
+from dataclasses import dataclass
+import logging
+import os
+import tempfile
+from typing import FrozenSet, List, Set
+
+import numpy as np
+import onnx
+from onnx import helper, numpy_helper
+
+
+logger = logging.getLogger(__name__)
+
+DERIVED_SUFFIX = ".tensorrt_panoptic.onnx"
+METRIC_OUTPUT_NAMES = frozenset(("metric_depth", "metric_points", "intrinsics"))
+MASK_SCATTER_PREFIX = "/model/panoptic_decoder/mask_transformer/ScatterND"
+
+
+@dataclass(frozen=True)
+class SanitizationReport:
+    """Summary of transformations applied to a derived ONNX graph."""
+
+    output_path: str
+    dropped_outputs: FrozenSet[str]
+    rewritten_mask_updates: int
+    removed_nodes: int
+
+
+def rewrite_mask_updates(model):
+    """Replace data-dependent mask ScatterND updates with broadcast Where."""
+    has_mask_updates = any(
+        node.op_type == "ScatterND" and node.name.startswith(MASK_SCATTER_PREFIX)
+        for node in model.graph.node
+    )
+    if not has_mask_updates:
+        return 0
+
+    nodes_by_name = {node.name: node for node in model.graph.node}
+    axes_name = "nvpanoptix3d_v2_trt_unsqueeze_last_axis"
+    false_name = "nvpanoptix3d_v2_trt_false"
+    existing_initializers = {item.name for item in model.graph.initializer}
+    if axes_name not in existing_initializers:
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.asarray([-1], dtype=np.int64), name=axes_name)
+        )
+    if false_name not in existing_initializers:
+        model.graph.initializer.append(
+            numpy_helper.from_array(np.asarray(False, dtype=np.bool_), name=false_name)
+        )
+
+    rewritten_nodes: List[onnx.NodeProto] = []
+    rewrite_count = 0
+    for node in model.graph.node:
+        is_mask_update = (
+            node.op_type == "ScatterND" and
+            node.name.startswith(MASK_SCATTER_PREFIX)
+        )
+        if not is_mask_update:
+            rewritten_nodes.append(node)
+            continue
+
+        nonzero_name = node.name.replace("/ScatterND", "/NonZero", 1)
+        nonzero_node = nodes_by_name.get(nonzero_name)
+        if nonzero_node is None or nonzero_node.op_type != "NonZero":
+            raise ValueError(
+                f"Expected matching NonZero node '{nonzero_name}' for mask "
+                f"update '{node.name}'."
+            )
+
+        data_input = node.input[0]
+        fully_masked_condition = nonzero_node.input[0]
+        expanded_condition = f"{node.name}/TensorRTSafeCondition_output_0"
+        rewritten_nodes.append(
+            helper.make_node(
+                "Unsqueeze",
+                inputs=[fully_masked_condition, axes_name],
+                outputs=[expanded_condition],
+                name=f"{node.name}/TensorRTSafeCondition",
+            )
+        )
+        rewritten_nodes.append(
+            helper.make_node(
+                "Where",
+                inputs=[expanded_condition, false_name, data_input],
+                outputs=list(node.output),
+                name=f"{node.name}/TensorRTSafeWhere",
+            )
+        )
+        rewrite_count += 1
+
+    model.graph.ClearField("node")
+    model.graph.node.extend(rewritten_nodes)
+    return rewrite_count
+
+
+def drop_metric_outputs(model):
+    """Remove derived metric outputs while retaining raw geometry outputs."""
+    dropped = {
+        output.name
+        for output in model.graph.output
+        if output.name in METRIC_OUTPUT_NAMES
+    }
+    retained_outputs = [
+        output
+        for output in model.graph.output
+        if output.name not in METRIC_OUTPUT_NAMES
+    ]
+    model.graph.ClearField("output")
+    model.graph.output.extend(retained_outputs)
+    return frozenset(dropped)
+
+
+def prune_dead_graph(model):
+    """Remove nodes and initializers that cannot reach a graph output."""
+    required_tensors: Set[str] = {output.name for output in model.graph.output}
+    retained_nodes = []
+    for node in reversed(model.graph.node):
+        if any(output in required_tensors for output in node.output):
+            retained_nodes.append(node)
+            required_tensors.update(name for name in node.input if name)
+    retained_nodes.reverse()
+
+    removed_nodes = len(model.graph.node) - len(retained_nodes)
+    model.graph.ClearField("node")
+    model.graph.node.extend(retained_nodes)
+
+    retained_initializers = [
+        item for item in model.graph.initializer if item.name in required_tensors
+    ]
+    model.graph.ClearField("initializer")
+    model.graph.initializer.extend(retained_initializers)
+
+    retained_value_info = [
+        item for item in model.graph.value_info if item.name in required_tensors
+    ]
+    model.graph.ClearField("value_info")
+    model.graph.value_info.extend(retained_value_info)
+    return removed_nodes
+
+
+def derived_path(onnx_path):
+    """Return the deterministic derived graph path beside ``onnx_path``."""
+    stem, extension = os.path.splitext(os.path.realpath(onnx_path))
+    if extension.lower() != ".onnx":
+        raise ValueError(f"Expected an .onnx model path, got: {onnx_path}")
+    return f"{stem}{DERIVED_SUFFIX}"
+
+
+def prepare_onnx_for_tensorrt(onnx_path):
+    """Create and return a TensorRT-safe derivative of ``onnx_path``.
+
+    External tensor payloads are deliberately not loaded or rewritten. The
+    derived protobuf remains in the source directory and references the same
+    sibling files as the original graph.
+    """
+    source_path = os.path.realpath(onnx_path)
+    output_path = derived_path(source_path)
+    model = onnx.load(source_path, load_external_data=False)
+    original_node_count = len(model.graph.node)
+
+    rewritten_mask_updates = rewrite_mask_updates(model)
+    dropped_outputs = drop_metric_outputs(model)
+    removed_nodes = prune_dead_graph(model)
+
+    remaining_ops = {node.op_type for node in model.graph.node}
+    if "TopK" in remaining_ops:
+        raise ValueError(
+            "NVPanoptix3Dv2 TensorRT graph still contains TopK after removing "
+            "the unsupported metric-output branch."
+        )
+    if "NonZero" in remaining_ops:
+        raise ValueError(
+            "NVPanoptix3Dv2 TensorRT graph still contains a data-dependent "
+            "NonZero operation after mask-update rewriting."
+        )
+
+    metadata = {item.key: item.value for item in model.metadata_props}
+    metadata["nvidia_tao_deploy.nvpanoptix3d_v2_tensorrt_sanitized"] = "1"
+    model.ClearField("metadata_props")
+    helper.set_model_props(model, metadata)
+
+    output_dir = os.path.dirname(output_path)
+    file_descriptor, temporary_path = tempfile.mkstemp(
+        prefix=f".{os.path.basename(output_path)}.",
+        suffix=".tmp",
+        dir=output_dir,
+    )
+    os.close(file_descriptor)
+    try:
+        onnx.save_model(model, temporary_path)
+        # Validate by path so ONNX resolves external tensor payloads relative
+        # to the source directory shared by the temporary and final graphs.
+        onnx.checker.check_model(temporary_path)
+        os.replace(temporary_path, output_path)
+    finally:
+        if os.path.exists(temporary_path):
+            os.unlink(temporary_path)
+
+    report = SanitizationReport(
+        output_path=output_path,
+        dropped_outputs=dropped_outputs,
+        rewritten_mask_updates=rewritten_mask_updates,
+        removed_nodes=removed_nodes,
+    )
+    logger.info(
+        "Prepared TensorRT ONNX graph %s: dropped outputs=%s, rewritten mask "
+        "updates=%d, pruned nodes=%d, nodes=%d->%d",
+        output_path,
+        ", ".join(sorted(dropped_outputs)) or "none",
+        rewritten_mask_updates,
+        removed_nodes,
+        original_node_count,
+        len(model.graph.node),
+    )
+    return report

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/scripts/__init__.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/scripts/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NVPanoptix3Dv2 deployment scripts."""

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/scripts/gen_trt_engine.py
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/scripts/gen_trt_engine.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build a TensorRT engine for an NVPanoptix3Dv2 panoptic ONNX export."""
+
+import logging
+import math
+import os
+
+from nvidia_tao_deploy.config.nvpanoptix3d_v2.default_config import ExperimentConfig
+from nvidia_tao_deploy.cv.common.decorators import monitor_status
+from nvidia_tao_deploy.cv.common.hydra.hydra_runner import hydra_runner
+from nvidia_tao_deploy.cv.common.initialize_experiments import (
+    initialize_gen_trt_engine_experiment,
+)
+from nvidia_tao_deploy.cv.nvpanoptix3d_v2.engine_builder import (
+    NVPanoptix3Dv2EngineBuilder,
+)
+
+
+logging.basicConfig(
+    format="%(asctime)s [TAO Toolkit] [%(levelname)s] %(name)s %(lineno)d: %(message)s",
+    level="INFO",
+)
+logger = logging.getLogger(__name__)
+SPEC_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PANOPTIC = "panoptic"
+
+
+def workspace_megabytes_to_gibibytes(workspace_size_mb):
+    """Convert the config's MB workspace value to builder GiB units.
+
+    The common TAO schema exposes workspace in MB while ``EngineBuilder``
+    accepts whole GiB. Rounding up preserves small, valid user requests rather
+    than accidentally passing a zero-byte TensorRT workspace.
+    """
+    if workspace_size_mb <= 0:
+        raise ValueError(
+            f"gen_trt_engine.tensorrt.workspace_size must be positive, got {workspace_size_mb}."
+        )
+    return max(1, math.ceil(workspace_size_mb / 1024))
+
+
+def validate_batch_profile(trt_config):
+    """Reject invalid dynamic-batch profile ordering before TensorRT runs."""
+    min_batch = trt_config.min_batch_size
+    opt_batch = trt_config.opt_batch_size
+    max_batch = trt_config.max_batch_size
+    if min_batch <= 0 or opt_batch <= 0 or max_batch <= 0:
+        raise ValueError(
+            "TensorRT min/opt/max batch sizes must all be positive, got "
+            f"{min_batch}, {opt_batch}, {max_batch}."
+        )
+    if not min_batch <= opt_batch <= max_batch:
+        raise ValueError(
+            "TensorRT batch profile must satisfy min_batch_size <= "
+            "opt_batch_size <= max_batch_size, got "
+            f"{min_batch} <= {opt_batch} <= {max_batch}."
+        )
+
+
+def run_engine_builder(cfg):
+    """Build and serialize the TensorRT engine described by ``cfg``."""
+    model_type = str(cfg.model.model_type)
+    if model_type != PANOPTIC:
+        raise ValueError(
+            f"TensorRT deployment supports model.model_type='{PANOPTIC}' only, "
+            f"got '{model_type}'."
+        )
+
+    onnx_file = cfg.gen_trt_engine.onnx_file
+    engine_file = cfg.gen_trt_engine.trt_engine
+    if not onnx_file:
+        raise ValueError("gen_trt_engine.onnx_file must point to the exported ONNX graph.")
+    if not os.path.isfile(onnx_file):
+        raise FileNotFoundError(f"ONNX file does not exist: {onnx_file}")
+    if not engine_file:
+        raise ValueError("gen_trt_engine.trt_engine must specify the output engine path.")
+    if os.path.realpath(onnx_file) == os.path.realpath(engine_file):
+        raise ValueError("The TensorRT engine path must not overwrite the input ONNX graph.")
+    batch_size = cfg.gen_trt_engine.batch_size
+    if batch_size == 0 or batch_size < -1:
+        raise ValueError(
+            "gen_trt_engine.batch_size must be positive or -1 for dynamic batch, "
+            f"got {batch_size}."
+        )
+
+    trt_config = cfg.gen_trt_engine.tensorrt
+    validate_batch_profile(trt_config)
+    workspace_gib = workspace_megabytes_to_gibibytes(trt_config.workspace_size)
+
+    engine_builder_kwargs, create_engine_kwargs = initialize_gen_trt_engine_experiment(cfg)
+    builder = NVPanoptix3Dv2EngineBuilder(
+        **engine_builder_kwargs,
+        workspace=workspace_gib,
+    )
+
+    # Parse by path so TensorRT can resolve the external data files emitted by
+    # the >2 GB NVPanoptix3Dv2 export without materializing another ONNX proto.
+    builder.create_network(onnx_file, file_format="onnx")
+    builder.create_engine(**create_engine_kwargs)
+    return engine_file
+
+
+@hydra_runner(
+    config_path=os.path.join(SPEC_ROOT, "specs"),
+    config_name="gen_trt_engine",
+    schema=ExperimentConfig,
+)
+@monitor_status(name="nvpanoptix3d_v2", mode="gen_trt_engine")
+def main(cfg: ExperimentConfig) -> None:
+    """Convert a panoptic ONNX export to a TensorRT engine."""
+    engine_file = run_engine_builder(cfg)
+    logger.info("TensorRT engine was saved at %s.", engine_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/nvidia_tao_deploy/cv/nvpanoptix3d_v2/specs/gen_trt_engine.yaml
+++ b/nvidia_tao_deploy/cv/nvpanoptix3d_v2/specs/gen_trt_engine.yaml
@@ -1,0 +1,13 @@
+results_dir: "???"
+gen_trt_engine:
+  gpu_id: 0
+  onnx_file: "???"
+  trt_engine: "???"
+  batch_size: -1
+  verbose: false
+  tensorrt:
+    data_type: FP32
+    workspace_size: 8192  # MB
+    min_batch_size: 1
+    opt_batch_size: 1
+    max_batch_size: 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please write the PR title to summarize what this PR proposes — it becomes the
changelog entry and the squashed commit subject. Prefix with the change type,
e.g. "fix(cli): reject empty annotation records".

Fill in every section below. A reviewer should be able to understand what
changed and why, and trust that it works, without reading the diff first.
Keep the description updated as the PR evolves.

If the PR is unfinished, open it as a Draft, or prefix the title with [WIP].
Do NOT use a pull request to report a security vulnerability — see SECURITY.md.
-->

### What changes are proposed in this pull request?

<!--
Outline what you changed and how it addresses the problem. Notes that make review
faster belong here: a class or module layout if you restructured something, a link
to a design document or issue discussion, references to how other projects solve
the same problem.

If this adds or changes a user-facing capability, include a short usage example:

  ```python
  # how someone uses this
  ```
-->
Add TAO Deploy support for the NVPanoptix3Dv2 panoptic model, including configuration, ONNX sanitization, TensorRT engine generation, ScanNet++ data loading, inference/postprocessing utilities, command registration, documentation, and unit tests.


### Why are the changes needed?

<!--
The motivation, not the mechanics. If you fix a bug, explain why the old behavior
was wrong. If you add an API, explain the use case it unblocks. Summarize this
even when it lives in an issue — reviewers should not need another tab.
-->
NVPanoptix3Dv2 requires a deployment path for converting its exported panoptic ONNX model into a TensorRT engine and running multi-view ScanNet++ inference.

### Related issues

<!--
"Fixes #123" / "Closes #123" to auto-close on merge, or "Part of #456".
Write "N/A" if there is no associated issue. Substantial changes should have an
issue discussing the approach before the code is written.
-->
Part of TAOVN-1258

### Does this PR introduce _any_ user-facing change?

<!--
This means *any* change a user could notice: new features, bug fixes, changed
output, renamed flags, different defaults, altered error messages, schema or API
changes. Documentation-only updates are not user-facing.

If yes: describe the previous behavior and the new behavior, and show the
difference — console output before and after is ideal. Call out explicitly
whether it breaks existing usage, and what users must do to migrate.

If no, write "No".
-->
Yes.

Users can now generate a TensorRT engine for an NVPanoptix3Dv2 panoptic ONNX export:

```bash
nvpanoptix3d_v2 gen_trt_engine \
    --config-name=gen_trt_engine \
    gen_trt_engine.onnx_file=/workspace/model.onnx \
    gen_trt_engine.trt_engine=/workspace/model.engine \
    gen_trt_engine.tensorrt.data_type=FP16
```

The implementation also provides programmatic ScanNet++ data loading, TensorRT inference, and panoptic postprocessing.

This is additive and does not break existing TAO Deploy workflows. TensorRT deployment currently supports the panoptic variant only; reasoning exports are rejected with a clear error.


### How was this patch tested?

<!--
Be specific: the commands you ran, the tests you added, and any manual
verification. "CI is green" is not a test plan for a behavior change.
Cover the negative cases too, not just the happy path.
If you did not add tests, say why it was difficult or unnecessary.

  $ <test command>
-->

<!-- Paste the relevant output: test summary, before/after comparison, or
     benchmark numbers. Redact tokens, credentials, and private paths. -->

Unit tests:

```bash
python -m pytest -q tests/nvpanoptix3d_v2
```

```text
44 passed
```

### Was this patch authored or co-authored using generative AI tooling?

<!--
Generative AI tooling is allowed, and you remain fully responsible for what you
submit: you must understand every line, have run it, and be able to answer review
questions about it. PRs the author cannot explain will be closed.

If AI tooling was used, include the line below with the tool name and version.
If no, write "No".

Generated-by: <tool name and version>
-->
Yes — portions were co-authored with an AI coding assistant.

### Release note

<!--
One sentence, written for a user reading the changelog — not for a reviewer
reading the diff. Write "NONE" if this change is invisible to users.

Good:  Fixed a crash when converting datasets containing empty annotation records.
Bad:   Refactored the converter and fixed a bug.
-->

```release-note
Added TensorRT engine generation and inference utilities for the NVPanoptix3Dv2 panoptic model.
```

### Checklist

- [x] My commits are signed off per the DCO (`git commit -s`) — see `CONTRIBUTING.md`
- [x] I have read the contributing guidelines
- [x] The code follows the project's style, and lint and format checks pass locally
- [x] I added or updated tests covering this change
- [x] All tests pass locally
- [ ] I added or updated documentation (README, docstrings, docs pages, examples)
- [ ] I updated the version, changelog, or migration notes if this change requires it
- [x] If this touches components that are optional to install, the imports are guarded
      so the package still works without them (reviewers: please verify this)
- [x] No secrets, credentials, proprietary data, or customer data are included in this PR
- [x] I understand this contribution is licensed under the repository's license, and that
      my commit author name and email become permanently public once merged

### Notes for reviewers

<!--
Anything that makes review faster: where to start, decisions you were unsure
about, areas you want scrutinized, or follow-up work deliberately left out.
Reviewers are volunteers on other schedules — if you see no response after a few
days, a polite ping on this PR is welcome.
-->
