### PR TITLE
[TAO-1796][Bugfix] video_clip: correct gt_queries docstring and fp16 spec guidance (tlt-docs !769 follow-ups)

### DIFF
--- a/nvidia_tao_deploy/config/multimodal/video_clip/default_config.py
+++ b/nvidia_tao_deploy/config/multimodal/video_clip/default_config.py
@@ -62,8 +62,8 @@ class VideoCLIPEvalDataConfig:
         value=MISSING,
         default_value=MISSING,
         description="Explicit-relevance eval file (e.g. domain_test_*.json) with "
-                    "'gallery' and 'queries' (each query: text, chunk_id, slice, "
-                    "relevant_clip_ids).",
+                    "'gallery' and 'queries' (each query record: query, chunk_id, "
+                    "slice, relevant_clip_ids).",
         display_name="Ground-truth Queries",
     )
     metadata: str = STR_FIELD(

--- a/nvidia_tao_deploy/multimodal/video_clip/specs/experiment_spec.yaml
+++ b/nvidia_tao_deploy/multimodal/video_clip/specs/experiment_spec.yaml
@@ -21,7 +21,7 @@ gen_trt_engine:
   batch_size: -1               # -1 for dynamic batch
   tensorrt:
     workspace_size: 8192       # MB
-    data_type: fp32            # fp32 required — fp16 collapses the vision tower
+    data_type: fp32            # fp32 recommended; fp16 supported (sensitive vision-norm reductions are kept in FP32)
     min_batch_size: 1
     opt_batch_size: 8
     max_batch_size: 16

--- a/tests/video_clip/test_config.py
+++ b/tests/video_clip/test_config.py
@@ -4,6 +4,7 @@
 """Video-CLIP deploy config unit tests."""
 
 from nvidia_tao_deploy.config.multimodal.video_clip.default_config import (
+    VideoCLIPEvalDataConfig,
     VideoCLIPTrtConfig,
     VideoCLIPModelConfig,
 )
@@ -19,3 +20,10 @@ def test_default_image_size_and_type():
     assert m.image_size == 224
     assert m.type == "internvideo2-clip-l14"
     assert m.canonicalize_text is False
+
+
+def test_gt_queries_docstring_names_the_query_key():
+    """The evaluator reads each record's ``query`` (scripts/evaluate.py); the field docs must match."""
+    description = VideoCLIPEvalDataConfig.__dataclass_fields__["gt_queries"].metadata["description"]
+    assert "query, chunk_id, slice, relevant_clip_ids" in description
+    assert "text," not in description


### PR DESCRIPTION
## What

Two documentation-contract fixes for `video_clip` from the InternVideo2-CLIP docs MR [tlt-docs !769](https://gitlab-master.nvidia.com/tlt/tlt-docs/-/merge_requests/769) (its follow-ups for the video_clip owners). No runtime change.

| Follow-up | Fix |
|---|---|
| `VideoCLIPEvalDataConfig.gt_queries` docstring listed the query text key as `text`, but the evaluator reads `q["query"]` (`scripts/evaluate.py`) | Docstring now names the real record keys: `query, chunk_id, slice, relevant_clip_ids`. |
| Shipped deploy spec comment said `fp32 required — fp16 collapses the vision tower`, which misled the docs; `gen_trt_engine` supports FP16 and auto-pins the sensitive vision-block normalization reductions to FP32 (the collapse only affects an unprotected weakly-typed build) | Comment now reads `fp32 recommended; fp16 supported (sensitive vision-norm reductions are kept in FP32)`, matching the `VideoCLIPTrtConfig.data_type` description. |

## Tests

- `tests/video_clip/test_config.py`: new `test_gt_queries_docstring_names_the_query_key` guards the field description against drifting from the evaluator's key again.
- `pytest tests/video_clip/test_config.py` -> 3 passed (inside `tao-toolkit-deploy:7.2.0-rc-47-multiarch`); flake8 clean.

Companion tao-pytorch PR for the remaining !769 follow-ups (shipped export spec values, `onnx_file` docstring, weight-source comment, dead `search.enabled`) is NVIDIA-TAO/tao-pytorch#131. Labeled `release/7.2.0` for `tao-cherry-pick-bot`. Please `/build` (I am not in the authorized list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
